### PR TITLE
Update docker to include top-level public assets

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ COPY package-lock.json /app
 COPY package.json /app
 COPY babel.config.js /app
 COPY vue.config.js /app
+COPY public /app/public
 COPY src /app/src
 
 # install and cache app dependencies

--- a/docker/Dockerfile-static
+++ b/docker/Dockerfile-static
@@ -8,6 +8,7 @@ COPY package.json /app
 COPY babel.config.js /app
 COPY vue.config.js /app
 COPY docker/.env-docker /app/.env
+COPY public /app/public
 COPY src /app/src
 
 RUN npm install --silent


### PR DESCRIPTION
They're now served when using either `serve` or `build` from inside docker. The Nginx container hasn't been tested, but the application container has.