### PR TITLE
#171 Resources and Support Button

### DIFF
--- a/src/assets/data/navigation.json
+++ b/src/assets/data/navigation.json
@@ -277,7 +277,7 @@
     "id": "5",
     "label": "Resources & Support",
     "path": "ResourcesSupport",
-    "primaryNavPath": "/ResourcesSupport/ReportRequest",
+    "primaryNavPath": "/ResourcesSupport/Resources",
     "submenu": {
       "Resources": {
         "id": "5.0",


### PR DESCRIPTION
Updated resources and support button to now go to 'Resources' page (first link) instead of Report/Request page