### PR TITLE
#166 Updated CVRF links to old website

### DIFF
--- a/src/views/Downloads.vue
+++ b/src/views/Downloads.vue
@@ -122,29 +122,29 @@
                     XML Files By Year:
                   </p>
                   <ul class="mt-0 tile-body cve-task-tile-list cve-list-no-bullet">
-                    <li><a href="/data/downloads/allitems-cvrf-year-2021.xml">CVE-2021-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2020.xml">CVE-2020-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2019.xml">CVE-2019-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2018.xml">CVE-2018-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2017.xml">CVE-2017-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2016.xml">CVE-2016-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2015.xml">CVE-2015-xxxxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2014.xml">CVE-2014-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2013.xml">CVE-2013-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2012.xml">CVE-2012-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2011.xml">CVE-2011-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2010.xml">CVE-2010-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2009.xml">CVE-2009-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2008.xml">CVE-2008-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2007.xml">CVE-2007-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2006.xml">CVE-2006-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2005.xml">CVE-2005-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2004.xml">CVE-2004-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2003.xml">CVE-2003-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2002.xml">CVE-2002-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2001.xml">CVE-2001-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-2000.xml">CVE-2000-xxxx records</a></li>
-                    <li><a href="/data/downloads/allitems-cvrf-year-1999.xml">CVE-1999-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2021.xml">CVE-2021-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2020.xml">CVE-2020-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2019.xml">CVE-2019-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2018.xml">CVE-2018-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2017.xml">CVE-2017-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2016.xml">CVE-2016-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2015.xml">CVE-2015-xxxxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2014.xml">CVE-2014-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2013.xml">CVE-2013-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2012.xml">CVE-2012-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2011.xml">CVE-2011-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2010.xml">CVE-2010-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2009.xml">CVE-2009-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2008.xml">CVE-2008-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2007.xml">CVE-2007-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2006.xml">CVE-2006-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2005.xml">CVE-2005-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2004.xml">CVE-2004-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2003.xml">CVE-2003-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2002.xml">CVE-2002-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2001.xml">CVE-2001-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-2000.xml">CVE-2000-xxxx records</a></li>
+                    <li><a href="https://cve.mitre.org/data/downloads/allitems-cvrf-year-1999.xml">CVE-1999-xxxx records</a></li>
                   </ul>
                 </article>
               </div>


### PR DESCRIPTION
Updated CVRF download links to go to old website (previously the links sent to a 404).

#166 