### PR TITLE
#192 Content updates to glossary page

### DIFF
--- a/src/assets/data/faqs.json
+++ b/src/assets/data/faqs.json
@@ -166,7 +166,7 @@
 				"questionId": "what_is_cve_record",
 				"questionText": "What is a CVE Record",
 				"questionResponseParagraphs": [
-					"A CVE Record is the descriptive data about a <a href='/About/Glossary?activeTerm=glossaryVulnerability'>vulnerability</a> associated with a CVE ID, provided by a <a href='/About/Glossary?activeTerm=glossaryCNA'>CVE Numbering Authority (CNA)</a>, and enriched by <a href='/About/Glossary?activeTerm=glossaryADP'>Authorized Data Publishers (ADPs)</a>. This data is provided in multiple human and machine-readable formats.",
+					"A CVE Record is the descriptive data about a <a href='/About/Glossary?activeTerm=glossaryVulnerability'>vulnerability</a> associated with a CVE ID, provided by a <a href='/About/Glossary?activeTerm=glossaryCNA'>CVE Numbering Authority (CNA)</a>, and enriched by Authorized Data Publishers (ADPs). This data is provided in multiple human and machine-readable formats.",
 					"See <a href='/About/Process#CVE_Records'>CVE Process</a> for additional information."
 				]
 			},

--- a/src/assets/data/glossaryEntries.json
+++ b/src/assets/data/glossaryEntries.json
@@ -1,9 +1,5 @@
 [
-    {
-        "id": "glossaryADP",
-	"term": "Authorized Data Publisher (ADP)",
-	"definition": "An organization authorized within the <span class='cve-term-reference'>CVE Program</span> to enrich a <span class='cve-term-reference'>CVE Record</span> previously published by a CNA with additional, related information (e.g., risk scores, affected product lists, and versions [i.e., references, translations]) within a defined Scope."
-    },
+
     {
 	"id": "glossaryCVE",
 	"term": "CVE",
@@ -16,7 +12,7 @@
     },
     {
 	"id": "glossaryCVEID",
-	"term": "CVE ID",
+	"term": "CVE Identifier (CVE ID)",
 	"definition": "A unique, alphanumeric identifier assigned by the <span class='cve-term-reference'>CVE Program</span>. Each identifier references a specific vulnerability. A CVE ID enables automation and multiple parties to discuss, share, and correlate information about a specific vulnerability, knowing they are referring to the same thing."
     },
     {
@@ -37,12 +33,12 @@
     {
 	"id": "glossaryProgram",
 	"term": "CVE Program",
-	"definition": "An international, community-driven effort to catalog <span class='cve-term-reference'>Vulnerabilities</span> in accordance with the effort’s rules and guidelines."
+	"definition": "An international, community-driven effort to catalog <span class='cve-term-reference'>vulnerabilities</span> in accordance with the effort’s rules and guidelines."
     },
     {
 	"id": "glossaryRecord",
 	"term": "CVE Record",
-	"definition": "The descriptive data about a <span class='cve-term-reference'>Vulnerability</span> associated with a <span class='cve-term-reference'>CVE ID</span>, provided by a <span class='cve-term-reference'>CNA</span>, and enriched by <span class='cve-term-reference'>ADPs</span>. This data is provided in multiple human and machine-readable formats. <p>A CVE Record is associated with one of the following states:</p><ul class='cve-term-definition-list'><li><span class='cve-term-reference'>Reserved</span>: The initial state for a CVE Record; when the associated CVE ID is Reserved by a CNA.</li><li><span class='cve-term-reference'>Published</span>: When a CNA populates the data associated with a CVE ID as a CVE Record, the state of the CVE Record is Published. The associated data must contain an identification number (CVE ID), a prose description, and at least one public reference.</li><li><span class='cve-term-reference'>Rejected</span>: If the CVE ID and associated CVE Record should no longer be used, the CVE Record is placed in the Rejected state. A Rejected CVE Record remains on the CVE List so that users can know when it is invalid.</li></ul><p>See also:</p><ul class='cve-term-definition-list'><li>The full requirements for a CVE Record can be found in Section 8.1. CVE Entry Information Requirements of the CNA Rules document. Data elements within a CVE Record are defined in Section 7. Assignment Rules of the CNA Rules document.</li><li>See Section 8.3 Reference Requirements of the CNA Rules for the requirements for the <span class='cve-term-reference'>CVE Program</span> to consider a CVE ID public.</li></ul>"
+	"definition": "The descriptive data about a <span class='cve-term-reference'>Vulnerability</span> associated with a <span class='cve-term-reference'>CVE ID</span>, provided by a <span class='cve-term-reference'>CNA</span>. This data is provided in multiple human and machine-readable formats. <p>A CVE Record is associated with one of the following states:</p><ul class='cve-term-definition-list'><li><span class='cve-term-reference'>Reserved</span>: The initial state for a CVE Record; when the associated CVE ID is Reserved by a CNA.</li><li><span class='cve-term-reference'>Published</span>: When a CNA populates the data associated with a CVE ID as a CVE Record, the state of the CVE Record is Published. The associated data must contain an identification number (CVE ID), a prose description, and at least one public reference.</li><li><span class='cve-term-reference'>Rejected</span>: If the CVE ID and associated CVE Record should no longer be used, the CVE Record is placed in the Rejected state. A Rejected CVE Record remains on the CVE List so that users can know when it is invalid.</li></ul><p>See also:</p><ul class='cve-term-definition-list'><li>The full requirements for a CVE Record can be found in <a href='/ResourcesSupport/AllResources/CNARules#section_8-1_cve_entry_information_requirements'> Section 8.1. CVE Record Information Requirements of the CNA Rules</a> document. Data elements within a CVE Record are defined in <a href ='/ResourcesSupport/AllResources/CNARules#section_7_assignment_rules'> Section 7. Assignment Rules </a> of the CNA Rules document.</li><li>See <a href ='/ResourcesSupport/AllResources/CNARules#section_8-3_cve_entry_reference_requirements'> Section 8.3 Reference Requirements</a> of the CNA Rules for the requirements for the <span class='cve-term-reference'>CVE Program</span> to consider a CVE ID public.</li></ul>"
     },
     {
 	"id": "glossaryWG",
@@ -56,8 +52,8 @@
     },
     {
 	"id": "glossaryRoot",
-	"term": "Root CNA",
-	"definition": "An organization authorized within the <span class='cve-term-reference'>CVE Program</span> that is responsible, within a specific Scope, for the recruitment, training, and governance of one or more entities that are a CVE <span class='cve-term-reference'>CNA</span>, <span class='cve-term-reference'>CNA-LR</span>, an <span class='cve-term-reference'>ADP</span>, or another Root CNA."
+	"term": "Root",
+	"definition": "An organization authorized within the <span class='cve-term-reference'>CVE Program</span> that is responsible, within a specific Scope, for the recruitment, training, and governance of one or more entities that are a <span class='cve-term-reference'>CNA</span>, <span class='cve-term-reference'>CNA-LR</span>, or another Root."
     },
     {
 	"id": "glossaryScope",
@@ -71,8 +67,8 @@
     },
     {
 	"id": "glossaryTLRCNA",
-	"term": "Top-Level Root CNA (TLR-CNA)",
-	"definition": "A <span class='cve-term-reference'>Root CNA</span> that does not report to another Root CNA, and is thus responsible to the <span class='cve-term-reference'>CVE Board</span>."
+	"term": "Top-Level Root (TL-Root)",
+	"definition": "A <span class='cve-term-reference'>Root</span> that does not report to another Root, and is thus responsible to the <span class='cve-term-reference'>CVE Board</span>."
     },
     {
 	"id": "glossaryVulnerability",

--- a/src/components/HomeModule.vue
+++ b/src/components/HomeModule.vue
@@ -11,7 +11,7 @@
                   The CVE Program partners with community members worldwide to grow CVE content and expand its usage. Click below to learn more
                   about the role of <router-link to="/About/Glossary?activeTerm=glossaryCNA">CVE Numbering Authorities(CNAs)</router-link>,
                   <router-link to="/About/Glossary?activeTerm=glossaryRoot">Root CNAs</router-link>, and
-                  <router-link to="/About/Glossary?activeTerm=glossaryADP">Authorized Data Publishers</router-link>.
+                  Authorized Data Publishers.
                 </p>
                 <div class="buttons is-centered">
                   <router-link to="/PartnerInformation/Partner" class="button cve-button cve-button-base-color">Learn More</router-link>

--- a/src/views/About/Process.vue
+++ b/src/views/About/Process.vue
@@ -126,7 +126,7 @@
                         <div class="block">
                           <p>A CVE Record is the descriptive data about a vulnerability associated with a CVE ID, provided by a CVE Numbering
                             Authority (<router-link to='/About/Glossary?activeTerm=glossaryCNA'>CNA</router-link>), and enriched by
-                            Authorized Data Publishers (<router-link to='/About/Glossary?activeTerm=glossaryADP'>ADPs</router-link>).
+                            Authorized Data Publishers (ADPs).
                             This data is provided in multiple human and machine-readable formats.
                           </p>
                           <p>Each CVE Record includes the following:</p>

--- a/src/views/PartnerInformation/Partner.vue
+++ b/src/views/PartnerInformation/Partner.vue
@@ -10,7 +10,7 @@
               about the roles of organizations participating as <a href='/About/Glossary?activeTerm=glossaryVulnerability'>vulnerability</a>
               associated with a CVE ID, provided by a <a href='/About/Glossary?activeTerm=glossaryCNA'>CVE Numbering Authority (CNA)</a>,
               <a href='/About/Glossary?activeTerm=glossaryRoot'>Root CNAs</a>, and
-              <a href='/About/Glossary?activeTerm=glossaryADP'>Authorized Data Publishers (ADPs)</a>.
+              Authorized Data Publishers (ADPs).
             </p>
 
             <div class="content pt-4 is-hidden-desktop">


### PR DESCRIPTION
Note: Because Authorized Data Publisher (ADP) was removed from the glossary, I removed the links that would take you to ADP under glossary.

#192 