### PR TITLE
#39 drop 'is' from <cve-id> is not found, ref and nvd urls opens in n…

### DIFF
--- a/src/views/CVERecord.vue
+++ b/src/views/CVERecord.vue
@@ -19,7 +19,7 @@
             <p v-if="this.$store.state.showHelpText" style="text-align: center;">Please use the search box above to find a CVE record by ID.</p>
             <div v-if="!this.$store.state.isSearching && !this.$store.state.showHelpText && !this.$store.state.serverError">
               <div v-if="this.$store.state.error" style="text-align: center !important">
-                <h2 class="title mb-2">{{this.$store.state.cveId}} is not found.</h2>
+                <h2 class="title mb-2">{{this.$store.state.cveId}} not found.</h2>
                 <span class="icon-text">
                   <a href="https://cve.mitre.org/cve/search_cve_list.html" target="_blank">
                   Find CVE Record by Keyword
@@ -98,7 +98,8 @@
                               <li v-if="ProductVersion !== undefined">
                                 <span class="has-text-weight-bold">Product: </span><span v-html="$sanitize(ProductVersion.product_name)"></span>
                               </li>
-                              <li v-if="ProductVersion.vendor_version.version_value && ProductVersion.vendor_version.version_value.length > 0">
+                              <li v-if="ProductVersion.vendor_version.version_value && ProductVersion.vendor_version.version_value.length > 0
+                                && ProductVersion.vendor_version.version_value[0] !== ''">
                                 <span class="has-text-weight-bold">Versions:</span>
                                 <span v-html="$sanitize(ProductVersion.vendor_version.version_value.join(', '))"></span>
                               </li>
@@ -115,14 +116,14 @@
                         <td>
                           <ul v-for="reference in this.$store.state.recordData.reference_data" :key="reference.index">
                             <li v-if="reference.url !== undefined" class="cve-task-tile-list-item">
-                              <a :href="$sanitize(reference.url)" class="cve-word-wrap">
+                              <a :href="$sanitize(reference.url)" class="cve-word-wrap" target="_blank">
                                 {{reference.name === undefined ? $sanitize(reference.url) : $sanitize(reference.name)}}
                               </a>
                             </li>
                           </ul>
                           <span>
                             View additional information about
-                            <a :href="`https://nvd.nist.gov/view/vuln/detail?vulnId=${this.$store.state.recordData.ID}`">
+                            <a :href="`https://nvd.nist.gov/view/vuln/detail?vulnId=${this.$store.state.recordData.ID}`" target="_blank">
                               {{this.$store.state.recordData.ID}}
                               <span class="icon cve-icon-xxs">
                                 <p id="nvd" class="is-hidden">external site</p>


### PR DESCRIPTION
…ew tab, 'Version' is hidden if 1st element is empty