### PR TITLE
#399 Replace Board Mail Archive link

### DIFF
--- a/src/views/ProgramOrganization/Board.vue
+++ b/src/views/ProgramOrganization/Board.vue
@@ -36,7 +36,7 @@
                     <a href="https://cve.mitre.org/community/board/archive.html#meeting_summaries" target="_blank">
                     Board Meeting Summaries</a></li>
                     <li class="cve-task-tile-list-item">
-                      <a href="http://common-vulnerabilities-and-exposures-cve-board.1128451.n5.nabble.com/" target="_blank">Board
+                      <a href="https://www.mail-archive.com/cve-editorial-board-list@mitre.org/" target="_blank">Board
                         Email Discussion List</a>
                     </li>
                   </ul>


### PR DESCRIPTION
Replace broken Nabble link with new Mail-Archive.com link