### PR TITLE
#516 remove extraneous ';', replace ';' with ':', and render version_…

### DIFF
--- a/src/views/CVERecord.vue
+++ b/src/views/CVERecord.vue
@@ -98,23 +98,30 @@
                       </tr>
                       <tr v-if=" this.$store.state.recordData.affects !== undefined && this.$store.state.recordData.affects.vendors !== undefined &&
                         this.$store.state.recordData.affects.vendors.length > 0 &&
-                        this.$store.state.recordData.affects.vendors[0].vendor_name !== 'n/a'">
+                        (this.$store.state.recordData.affects.vendors[0].vendor_name !== 'n/a'
+                          || (this.$store.state.recordData.affects.vendors[0].vendor_name == 'n/a' &&
+                            this.$store.state.recordData.affects.vendors[0].products[0].product_name !== 'n/a'))">
                         <th scope="row">Vendors, Products & Versions</th>
                         <td>
-                          <ul v-for="vendorProductVersion in this.$store.state.recordData.affects.vendors" :key="vendorProductVersion.index">
-                            <li>
-                              <span class="has-text-weight-bold">Vendor: </span><span>{{vendorProductVersion.vendor_name}}</span>
+                          <ul v-for="vendorProductVersion in this.$store.state.recordData.affects.vendors" :key="vendorProductVersion.index"
+                            class="ml-0">
+                            <li class="cve-list-no-bullet">
+                              <span class="has-text-weight-bold">Vendor: </span>
+                              <span v-if="vendorProductVersion.vendor_name == 'n/a'" class="is-italic">Not Specified</span>
+                              <span v-else>{{vendorProductVersion.vendor_name}}</span>
                             </li>
                             <ul v-for="ProductVersion in vendorProductVersion.products" :key="ProductVersion.index" class="mb-2">
-                              <li v-if="ProductVersion !== undefined">
+                              <li v-if="ProductVersion !== undefined" class="cve-list-no-bullet">
                                 <span class="has-text-weight-bold">Product: </span><span>{{ProductVersion.product_name}}</span>
                               </li>
-                              <li v-if="ProductVersion.vendor_version.length > 0">
-                                <span class="has-text-weight-bold">Versions Affected: </span>
+                              <li v-if="ProductVersion.vendor_version.length > 0" class="cve-list-no-bullet">
                                 <ul>
-                                  <li v-for="valueAffected in ProductVersion.vendor_version" :key="valueAffected.version_value">
+                                  <span class="has-text-weight-bold">Versions Affected: </span>
+                                  <li v-for="valueAffected in ProductVersion.vendor_version" :key="valueAffected.version_value.index"
+                                    class="ml-2 cve-list-no-bullet">
                                     <span v-if="valueAffected.version_affected != ''">
-                                      {{valueAffected.version_affected}}{{valueAffected.version_value}}; {{valueAffected.definition}}
+                                      {{valueAffected.version_affected}}{{valueAffected.version_value}}<span v-if="valueAffected.definition !== ''">:
+                                        {{valueAffected.definition}}</span>
                                     </span>
                                     <span v-else>
                                       {{valueAffected.version_value}}


### PR DESCRIPTION
…value and version_affected if they exist when a vendor_name is 'n/a'