### PR TITLE
#598 Added link to go to the onboarding videos

### DIFF
--- a/src/views/PartnerInformation/Partner.vue
+++ b/src/views/PartnerInformation/Partner.vue
@@ -254,7 +254,7 @@
                             <ul>
                               <li>CNA
                                 <ul>
-                                  <li>View guidance videos.</li>
+                                  <li>View <router-link to='/ResourcesSupport/Resources#CVENumberingAuthorities'>guidance videos</router-link>.</li>
                                   <li>Attend an introductory session.</li>
                                   <li>Successfully complete practice examples.</li>
                                 </ul>


### PR DESCRIPTION
The link goes to the section of the page that includes the table of onboarding videos.