### PR TITLE
Content rjr 607

### DIFF
--- a/src/assets/data/NotificationBanner.json
+++ b/src/assets/data/NotificationBanner.json
@@ -42,12 +42,12 @@
     {
       "contentType": "internalLink", 
       "link": "/Media/News/item/news/2021/09/29/Welcome-to-the-New-CVE",
-      "linkText": "transition"
+      "linkText": "transition."
     },  
 
     {
       "contentType": "paragraph", 
-      "content": ". Please use our "
+      "content": "Please use our "
     }, 
 
     {

--- a/src/assets/data/NotificationBanner.json
+++ b/src/assets/data/NotificationBanner.json
@@ -40,14 +40,14 @@
     }, 
 
     {
-      "contentType": "externalLink", 
-      "link": "https://cve.mitre.org/news/archives/2021/news.html#September022021_CVE_Website_Transitioning_to_New_Web_Address_-_CVE.ORG",
+      "contentType": "internalLink", 
+      "link": "/Media/News/item/news/2021/09/29/Welcome-to-the-New-CVE",
       "linkText": "transition"
     },  
 
     {
       "contentType": "paragraph", 
-      "content": " . Please use our "
+      "content": ". Please use our "
     }, 
 
     {

--- a/src/components/NotificationBannerModule.vue
+++ b/src/components/NotificationBannerModule.vue
@@ -25,7 +25,7 @@
                             {{ ' ' }}
                           </a>
                           <span v-if="section.contentType == 'internalLink'">
-                            <router-link :to="section.link">{{section.linkText}} </router-link>
+                            <router-link :to="section.link">{{section.linkText}}</router-link>
                           </span>
                         </span>
                       </div>
@@ -56,7 +56,7 @@
                           {{ ' ' }}
                         </a>
                         <span v-if="section.contentType == 'internalLink'">
-                          <router-link :to="section.link">{{section.linkText}} </router-link>
+                          <router-link :to="section.link">{{section.linkText}}</router-link>
                         </span>
                       </span>
                     </div>


### PR DESCRIPTION
Updated the "transition" link in the banner message to go to an internal link.

Can you please remove the extra blank space between the word 'transition' and the end period?  