### PR TITLE
#661 Add links to Resources for 7 Spanish videos

### DIFF
--- a/src/views/ProgramOrganization/WorkingGroups.vue
+++ b/src/views/ProgramOrganization/WorkingGroups.vue
@@ -15,7 +15,7 @@
               and Strategic Planning (SPWG).
             </p>
             <p>
-              A temporary WG, the <strong>Transition Working Group (TWG)</strong>, is focused on managing the numerous modernization, automation, 
+              A temporary WG, the <strong>Transition Working Group (TWG)</strong>, is focused on managing the numerous modernization, automation,
               and process transitions currently underway in the CVE Program.
             </p>
             <p>

--- a/src/views/ResourcesSupport/Resources.vue
+++ b/src/views/ResourcesSupport/Resources.vue
@@ -131,10 +131,10 @@
                   <tr>
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">CVE Program Overview</td>
                     <td data-label="Description">An introduction to the CVE Program, including what is CVE,
-                      goals of
-                      the program, who operates the program, and program organization.</td>
+                      goals of the program, who operates the program, and program organization.</td>
                     <td data-label="Slides"> <a href="https://cve.mitre.org/cve/cna/CVE_Program_Overview.pptx">English</a><br>
-                      <a href="https://cve.mitre.org/cve/cna/CVE_Program_Overview_ja.pptx">Japanese</a>
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Program_Overview_ja.pptx">Japanese</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Program_Overview_sp.pptx">Spanish</a><br>
                     </td>
                     <td data-label="Video"><a class="cve-social-media-icon" href="https://youtu.be/rrNYEUNsXOY" target="_blank">
                       <span class="icon">
@@ -145,14 +145,12 @@
                   </tr>
                   <tr>
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">Becoming a CNA</td>
-                    <td data-label="Description">An introduction to becoming a CVE Numbering Authority (CNA) with an overview of what defines a CNA,
-                      how
-                      the CVE Program is organized,
-                      how to organize your CNA program, how to define the scope of what you will cover, internal CNA processes,
-                      CNA resources, and ways to get
-                      involved in the CNA community.</td>
+                    <td data-label="Description">An introduction to becoming a CVE Numbering Authority (CNA) with an overview of what 
+                      defines a CNA, how the CVE Program is organized, how to organize your CNA program, how to define the scope of 
+                      what you will cover, internal CNA processes, CNA resources, and ways to get involved in the CNA community.</td>
                     <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/Becoming_a_CNA.pptx">English</a><br>
-                        <a href="https://cve.mitre.org/cve/cna/Becoming_a_CNA_ja.pptx">Japanese</a></td>
+                        <a href="https://cve.mitre.org/cve/cna/Becoming_a_CNA_ja.pptx">Japanese</a><br>
+                        <a href="https://cve.mitre.org/cve/cna/Becoming_a_CNA_sp.pptx">Spanish</a></td>
                     <td data-label="Video"><a class="cve-social-media-icon" href="https://youtu.be/13b5cuZR7CQ" target="_blank">
                       <span class="icon">
                         <p id="youTubeIcon4" class="is-hidden">YouTube video becoming a CNA</p>
@@ -167,6 +165,7 @@
                       dispute a CVE ID, and the process for handling expiring CVE IDs.</td>
                     <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CNA_Processes.pptx">English</a><br>
                       <a href="https://cve.mitre.org/cve/cna/CNA_Processes_ja.pptx">Japanese</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/CNA_Processes_sp.pptx">Spanish</a>
                     </td>
                     <td data-label="Video"><a class="cve-social-media-icon" href="https://youtu.be/nXqcjq2-Doc" target="_blank">
                       <span class="icon">
@@ -178,7 +177,8 @@
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">Assigning CVE IDs</td>
                     <td data-label="Description">Describes in detail how CNAs assign CVE IDs to vulnerabilities.</td>
                     <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/Assigning_CVE_IDs.pptx">English</a><br>
-                      <a href="https://cve.mitre.org/cve/cna/Assigning_CVE_IDs_ja.pptx">Japanese</a>
+                      <a href="https://cve.mitre.org/cve/cna/Assigning_CVE_IDs_ja.pptx">Japanese</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/Assigning_CVE_IDs_sp.pptx">Spanish</a>
                     </td>
                     <td data-label="Video"><a class="cve-social-media-icon" href="https://youtu.be/JQYq-mxLo-U" target="_blank">
                       <span class="icon">
@@ -192,8 +192,9 @@
                       Once a CNA has assigned a CVE ID(s), performed coordination to fix the vulnerability, and published the
                       vulnerability information, the next step is to populate the CVE Record (previously “CVE Entry”). This video
                       details how CNAs create CVE Records.</td>
-                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Entry_Creation.pptx">English</a><br>
-                      <a href="https://cve.mitre.org/cve/cna/CVE_Entry_Creation_ja.pptx">Japanese</a>
+                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Record_Creation.pptx">English</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Record_Creation_ja.pptx">Japanese</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Record_Creation_sp.pptx">Spanish</a>
                     </td>
                     <td data-label="Video"><a class="cve-social-media-icon" href="https://youtu.be/se-yM_LureQ" target="_blank">
                       <span class="icon">
@@ -204,7 +205,8 @@
                   <tr>
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">CVE Record GitHub Submissions</td>
                     <td data-label="Description">Describes the process for CNAs to submit CVE Records using GitHub.</td>
-                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Record_GitHub_Submission_slides-only.pptx">English</a>
+                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Record_GitHub_Submission_slides-only.pptx">English</a><br>
+                    <a href="https://cve.mitre.org/cve/cna/CVE_Record_GitHub_Submissions_sp.pptx">Spanish</a>
                     </td>
                     <td data-label="Video"></td>
                   </tr>
@@ -212,8 +214,9 @@
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">CVE Record Submission Process</td>
                     <td data-label="Description">Guidance for how to submit CVE Record (previously “CVE Entry”) to the MITRE Top-Level Root (TL-
                       Root).</td>
-                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Entry_Submission_Process.pptx">English</a><br>
-                      <a href="https://cve.mitre.org/cve/cna/CVE_Entry_Submission_Process_ja.pptx">Japanese</a>
+                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Record_Submission_Process_to_MITRE_Root_Only.pptx">English</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Record_Submission_Process_ja.pptx">Japanese</a><br>
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Record_Submissions_to_MITRE_Top-Level_Root_Only_sp">Spanish</a>
                     </td>
                     <td data-label="Video"><a class="cve-social-media-icon" href="https://youtu.be/5l4cxDw8lHc" target="_blank">
                       <span class="icon">

--- a/src/views/ResourcesSupport/Resources.vue
+++ b/src/views/ResourcesSupport/Resources.vue
@@ -214,7 +214,8 @@
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">CVE Record Submission Process</td>
                     <td data-label="Description">Guidance for how to submit CVE Record (previously “CVE Entry”) to the MITRE Top-Level Root (TL-
                       Root).</td>
-                    <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/CVE_Record_Submission_Process_to_MITRE_Root_Only.pptx">English</a><br>
+                    <td data-label="Slides">
+                      <a href="https://cve.mitre.org/cve/cna/CVE_Record_Submission_Process_to_MITRE_Root_Only.pptx">English</a><br>
                       <a href="https://cve.mitre.org/cve/cna/CVE_Record_Submission_Process_ja.pptx">Japanese</a><br>
                       <a href="https://cve.mitre.org/cve/cna/CVE_Record_Submissions_to_MITRE_Top-Level_Root_Only_sp">Spanish</a>
                     </td>

--- a/src/views/ResourcesSupport/Resources.vue
+++ b/src/views/ResourcesSupport/Resources.vue
@@ -145,8 +145,8 @@
                   </tr>
                   <tr>
                     <td data-label="Title" style="width: 40%" class="has-text-weight-bold">Becoming a CNA</td>
-                    <td data-label="Description">An introduction to becoming a CVE Numbering Authority (CNA) with an overview of what 
-                      defines a CNA, how the CVE Program is organized, how to organize your CNA program, how to define the scope of 
+                    <td data-label="Description">An introduction to becoming a CVE Numbering Authority (CNA) with an overview of what
+                      defines a CNA, how the CVE Program is organized, how to organize your CNA program, how to define the scope of
                       what you will cover, internal CNA processes, CNA resources, and ways to get involved in the CNA community.</td>
                     <td data-label="Slides"><a href="https://cve.mitre.org/cve/cna/Becoming_a_CNA.pptx">English</a><br>
                         <a href="https://cve.mitre.org/cve/cna/Becoming_a_CNA_ja.pptx">Japanese</a><br>


### PR DESCRIPTION
Links are for the Spanish translations of the CNA Onboarding videos, which are currently hosted on the old website.

For the 11/23 release.