### PR TITLE
#773 Fix 1 url + update 1 url on Events page

### DIFF
--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -20,7 +20,7 @@
             "location": "Virtual",
             "description": "A collaborative community event of CVE Partners focused on improving CVE.",
             "permission": "private",
-            "url": "",
+            "url": "/Media/News/item/blog/2021/12/07/CVE-Global-Summit-Fall-2021",
             "date": {
                 "start": "2021-10-26",
                 "end": "2021-10-27",
@@ -142,7 +142,7 @@
             "location": "Virtual",
             "description": "A collaborative community event of CVE Partners focused on improving CVE.",
             "permission": "private",
-            "url": "https://medium.com/@cve_program/cve-global-summit-spring-2021-4e6c3e00bfc5",
+            "url": "/Resources/Media/Archives/Blogs/2021/2021-06-10_CVE-Global-Summit-Spring-2021.pdf",
             "date": {
                 "start": "2021-05-13",
                 "end": "2021-05-14",


### PR DESCRIPTION
On Events page for the 12/21 release:

(1) Fix 1 missing url.
(2) Update 1 url from a Medium.com link to a Blog archive PDF.