### PR TITLE
#799 Add 1 additional Advisory link to 1 CNA

### DIFF
--- a/src/assets/data/CNAsList.json
+++ b/src/assets/data/CNAsList.json
@@ -10451,8 +10451,12 @@
         "advisories": [
           {
             "label": "Advisories",
+            "url": "https://github.com/openbmc/openbmc/issues?utf8=%E2%9C%93&q=Security+Advisory"
+          },
+          {
+            "label": "Advisories",
             "url": "https://github.com/openbmc/openbmc/security/advisories"
-          }
+          }          
         ]
       },
       "resources": [],


### PR DESCRIPTION
One of the Advisories links goes to a page that has not yet been populated, but will be over time, according to the CNA.