### PR TITLE
#1007 Update WGs & Resources pages with podcasts

### DIFF
--- a/src/views/ProgramOrganization/WorkingGroups.vue
+++ b/src/views/ProgramOrganization/WorkingGroups.vue
@@ -34,6 +34,21 @@
                 <a href="https://cveform.mitre.org/" class="button cve-button cve-button-accent-warm" target="_blank">Join a WG</a>
               </div>
             </div>
+            <br/>
+            <div class="cve-white-bg-gray-border-container">
+              <h3 class="title mt-4">Podcast - CVE Working Groups, What They Are and How They Improve CVE</h3>
+              <figure class ="image is-16by9">  <!-- podcast -->
+                <iframe class="has-ratio" width="460" height="215" src="https://www.youtube.com/embed/IT9HlBOeKKc" frameborder="0" allowfullscreen>
+                </iframe>
+              </figure>
+              <p>
+                The chairs and co-chairs of each of the six 
+                <a href='/ProgramOrganization/WorkingGroups'>CVE Working Groups (WGs)</a> &mdash; each of whom is an active member of the 
+                CVE community &mdash; chat about their WG’s overall mission, current work, and future plans. WGs help improve quality, automation, 
+                processes, and other aspects of the CVE Program as it continues to grow and expand. How and why to participate, and the impact 
+                individuals can make on the program, are also included.
+              </p>
+            </div>            
             <h2 :id="cvenavs['Program Organization']['submenu']['Working Groups']['items']['Automation Working Group (AWG)']['anchorId']"
             class="title cve-heading-top-spacing">
             {{cvenavs['Program Organization']['submenu']['Working Groups']['items']['Automation Working Group (AWG)']['label']}}</h2>

--- a/src/views/ProgramOrganization/WorkingGroups.vue
+++ b/src/views/ProgramOrganization/WorkingGroups.vue
@@ -42,13 +42,12 @@
                 </iframe>
               </figure>
               <p>
-                The chairs and co-chairs of each of the six 
-                <a href='/ProgramOrganization/WorkingGroups'>CVE Working Groups (WGs)</a> &mdash; each of whom is an active member of the 
-                CVE community &mdash; chat about their WG’s overall mission, current work, and future plans. WGs help improve quality, automation, 
-                processes, and other aspects of the CVE Program as it continues to grow and expand. How and why to participate, and the impact 
+                The chairs and co-chairs of each of the six CVE Working Groups (WGs) &mdash; each of whom is an active member of the
+                CVE community &mdash; chat about their WG’s overall mission, current work, and future plans. WGs help improve quality, automation,
+                processes, and other aspects of the CVE Program as it continues to grow and expand. How and why to participate, and the impact
                 individuals can make on the program, are also included.
               </p>
-            </div>            
+            </div>
             <h2 :id="cvenavs['Program Organization']['submenu']['Working Groups']['items']['Automation Working Group (AWG)']['anchorId']"
             class="title cve-heading-top-spacing">
             {{cvenavs['Program Organization']['submenu']['Working Groups']['items']['Automation Working Group (AWG)']['label']}}</h2>

--- a/src/views/ResourcesSupport/Resources.vue
+++ b/src/views/ResourcesSupport/Resources.vue
@@ -36,9 +36,12 @@
                           <br/><span class="cve-help-text">Establishes the policy for the EOL CVE assignment process</span>
                         </li>
                         <li>
-                          <router-link to="/Media/News/item/podcast/2022/05/03/Researchers-and-PSIRTs-Working-Well">Researchers and PSIRTs Working Well Together (Podcast)</router-link>
-                          <br/><span class="cve-help-text">What to expect when reporting vulnerabilities to a Product Security Incident Response Team (PSIRT), how to get the best outcome, supported versus EOL products, CNA scopes, timing of patch versus publication of CVE Record, and more</span>
-                      </li>                        
+                          <router-link to="/Media/News/item/podcast/2022/05/03/Researchers-and-PSIRTs-Working-Well">Researchers and PSIRTs Working
+                          Well Together (Podcast)</router-link>
+                          <br/><span class="cve-help-text">What to expect when reporting vulnerabilities to a Product Security Incident Response Team
+                          (PSIRT), how to get the best outcome, supported versus EOL products, CNA scopes, timing of patch versus publication of CVE
+                          Record, and more</span>
+                      </li>
                       </ul>
                     </article>
                   </div>
@@ -258,18 +261,18 @@
                           </a>
                         </li>
                         <li>
-                          <a href="https://cveproject.github.io/docs/cna/resources/Submitting%20New%20CVEs%20Using%20CLI.docx">Command
-                            Line Interface Setup
+                          <a href="https://cveproject.github.io/docs/cna/resources/Submitting%20New%20CVEs%20Using%20CLI.docx">
+                          Command Line Interface Setup
                           </a>
                         </li>
                         <li>
-                          <a href="https://cveproject.github.io/docs/cna/resources/Submitting%20New%20CVEs%20Using%20GitHub%20Desktop.docx">GitHub
-                            Desktop GUI Setup
+                          <a href="https://cveproject.github.io/docs/cna/resources/Submitting%20New%20CVEs%20Using%20GitHub%20Desktop.docx">
+                          GitHub Desktop GUI Setup
                           </a>
                         </li>
                         <li>
-                          <a href="https://cveproject.github.io/docs/cna/resources/Submitting%20New%20CVEs%20using%20SourceTree.docx">SourceTree
-                            GUI Setup
+                          <a href="https://cveproject.github.io/docs/cna/resources/Submitting%20New%20CVEs%20using%20SourceTree.docx">
+                          SourceTree GUI Setup
                           </a>
                         </li>
                       </ul>
@@ -309,13 +312,16 @@
                   </h3>
                   <ul class="mt-0 tile-body cve-task-tile-list">
                     <li>
-                      <router-link to="/Media/News/item/podcast/2021/09/07/CVE-Working-Groups-What-They">CVE Working Groups, What They Are and How They Improve CVE (Podcast)</router-link>
-                    </li>                  
-                    <li>
-                      <router-link to="/ProgramOrganization/WorkingGroups#AutomationWorkingGroupAWG">AWG Repositories &amp; Projects</router-link>
+                      <router-link to="/Media/News/item/podcast/2021/09/07/CVE-Working-Groups-What-They">CVE
+                      Working Groups, What They Are and How They Improve CVE (Podcast)</router-link>
                     </li>
                     <li>
-                      <router-link to="/ProgramOrganization/WorkingGroups#StrategicPlanningWorkingGroupSPWG">SPWG Repository </router-link>
+                      <router-link to="/ProgramOrganization/WorkingGroups#AutomationWorkingGroupAWG">AWG
+                      Repositories &amp; Projects</router-link>
+                    </li>
+                    <li>
+                      <router-link to="/ProgramOrganization/WorkingGroups#StrategicPlanningWorkingGroupSPWG">
+                      SPWG Repository </router-link>
                     </li>
                     <li>
                       <router-link to="/ProgramOrganization/WorkingGroups">Working Groups page</router-link>

--- a/src/views/ResourcesSupport/Resources.vue
+++ b/src/views/ResourcesSupport/Resources.vue
@@ -35,6 +35,10 @@
                           End-of-Life (EOL) Assignment Process (PDF, 0.3MB)</router-link>
                           <br/><span class="cve-help-text">Establishes the policy for the EOL CVE assignment process</span>
                         </li>
+                        <li>
+                          <router-link to="/Media/News/item/podcast/2022/05/03/Researchers-and-PSIRTs-Working-Well">Researchers and PSIRTs Working Well Together (Podcast)</router-link>
+                          <br/><span class="cve-help-text">What to expect when reporting vulnerabilities to a Product Security Incident Response Team (PSIRT), how to get the best outcome, supported versus EOL products, CNA scopes, timing of patch versus publication of CVE Record, and more</span>
+                      </li>                        
                       </ul>
                     </article>
                   </div>
@@ -305,13 +309,16 @@
                   </h3>
                   <ul class="mt-0 tile-body cve-task-tile-list">
                     <li>
+                      <router-link to="/Media/News/item/podcast/2021/09/07/CVE-Working-Groups-What-They">CVE Working Groups, What They Are and How They Improve CVE (Podcast)</router-link>
+                    </li>                  
+                    <li>
                       <router-link to="/ProgramOrganization/WorkingGroups#AutomationWorkingGroupAWG">AWG Repositories &amp; Projects</router-link>
-                      </li>
+                    </li>
                     <li>
                       <router-link to="/ProgramOrganization/WorkingGroups#StrategicPlanningWorkingGroupSPWG">SPWG Repository </router-link>
                     </li>
                     <li>
-                      <router-link to="/ProgramOrganization/WorkingGroups">Working Groups</router-link> page
+                      <router-link to="/ProgramOrganization/WorkingGroups">Working Groups page</router-link>
                     </li>
                     <li>
                       <a href="https://cveproject.github.io/" target="_blank">CVE Program Automation Website</a>


### PR DESCRIPTION
Working Groups page - add embedded YouTube file (same as how on About page, but smaller frame).
Resources page:
       - add link to the WGs podcast episode page as a WGs resource item.
       - add link to the Researchers podcast episode page as a Researchers resource item.