### PR TITLE
Tat 1147

### DIFF
--- a/src/components/NavigationSidebar.vue
+++ b/src/components/NavigationSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="menu is-hidden-touch cve-sidebar-menu mt-3">
+  <aside class="menu cve-sidebar-menu mt-3" :class="isNavSidebarHiddenTouch ? 'is-hidden-touch' : ''">
     <p class="menu-label cve-capitalize-first-letter">{{nav.label}}</p>
     <ul class="menu-list cve-capitalize-first-letter">
       <li v-for="(submenuObj, submenuLabel) in nav.submenu" :key="submenuObj.id">
@@ -45,6 +45,10 @@ export default {
     nav: {
       type: Object,
       required: true,
+    },
+    isNavSidebarHiddenTouch: {
+      type: Boolean,
+      required: false,
     },
   },
   data() {

--- a/src/components/NewsModule.vue
+++ b/src/components/NewsModule.vue
@@ -78,8 +78,8 @@
         </main>
         <SurveyLinkComponent :surveyLink="cvenavs['AllNews']['surveyLink']" />
       </div>
-      <div class="column is-3 is-hidden-touch">
-        <NavigationSidebar :nav="cvenavs['AllNews']" />
+      <div class="column is-3" :class="isNavSidebarHiddenTouch ? 'is-hidden-touch' : ''">
+        <NavigationSidebar :nav="cvenavs['AllNews']" :isNavSidebarHiddenTouch="isNavSidebarHiddenTouch"/>
       </div>
     </div>
   </div>
@@ -111,6 +111,7 @@ export default {
         pages: [],
         currentNewsToDisplay: [],
       },
+      isNavSidebarHiddenTouch: false,
     };
   },
   mixins: [newsMixins],

--- a/src/views/Media/News/BlogArchives.vue
+++ b/src/views/Media/News/BlogArchives.vue
@@ -63,8 +63,8 @@
           </div>
         </main>
       </div>
-      <div class="column is-3 is-hidden-touch">
-        <NavigationSidebar :nav="cvenavs['AllNews']" />
+      <div class="column is-3" :class="isNavSidebarHiddenTouch ? 'is-hidden-touch' : ''">
+        <NavigationSidebar :nav="cvenavs['AllNews']" :isNavSidebarHiddenTouch="isNavSidebarHiddenTouch"/>
       </div>
     </div>
   </div>
@@ -84,6 +84,7 @@ export default {
       archiveBlogs: newsData.archiveBlogs,
       accordian: [],
       sortedEntries: {},
+      isNavSidebarHiddenTouch: false,
     };
   },
   created() {

--- a/src/views/Media/News/NewsArchives.vue
+++ b/src/views/Media/News/NewsArchives.vue
@@ -20,8 +20,8 @@
           </div>
         </main>
       </div>
-      <div class="column is-3 is-hidden-touch">
-        <NavigationSidebar :nav="cvenavs['AllNews']" />
+      <div class="column is-3"  :class="isNavSidebarHiddenTouch ? 'is-hidden-touch' : ''">
+        <NavigationSidebar :nav="cvenavs['AllNews']" :isNavSidebarHiddenTouch="isNavSidebarHiddenTouch"/>
       </div>
     </div>
   </div>
@@ -39,6 +39,7 @@ export default {
   data() {
     return {
       archivedNews: newsData.archiveNews,
+      isNavSidebarHiddenTouch: false,
     };
   },
   props: {


### PR DESCRIPTION
Expected behaviors:

- right nav appears on all News-related pages in touch devices: All News, Recent: News, Blogs, Podcasts, Archives: News Articles, Blogs