### PR TITLE
#1027 add ability to link custom feedback form for each of the news types

### DIFF
--- a/src/assets/data/navigation.json
+++ b/src/assets/data/navigation.json
@@ -326,17 +326,20 @@
                 "News Articles": {
                     "id": "6.1.1",
                     "label": "News Articles",
-                    "path": "News"
+                    "path": "News",
+                    "surveyLink": "https://forms.office.com/Pages/ResponsePage.aspx?id=SNwgxlAdUkmLOd9NVNdNgksLeUGJ_vlDujipnPAHzqlUQjU5WVc3UkQxVUNHRUIyS1lQVlQ4N0lGWiQlQCN0PWcu"
                 },
                 "Blogs": {
                     "id": "6.1.2",
                     "label": "Blogs",
-                    "path": "Blogs"
+                    "path": "Blogs",
+                    "surveyLink": "https://forms.office.com/pages/designpagev2.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNURUsxMVA4OVlYQTAxT1VLRVpOU1o1MFFDVy4u"
                 },
                 "Podcasts": {
                     "id": "6.1.3",
                     "label": "Podcasts",
-                    "path": "Podcasts"
+                    "path": "Podcasts",
+                    "surveyLink": "https://forms.office.com/pages/designpagev2.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNUNllQWFpVT0FDTkhJMUxNTU9FSFI5S08yVi4u"
                 }
             }
         },

--- a/src/assets/data/navigation.json
+++ b/src/assets/data/navigation.json
@@ -333,13 +333,13 @@
                     "id": "6.1.2",
                     "label": "Blogs",
                     "path": "Blogs",
-                    "surveyLink": "https://forms.office.com/pages/designpagev2.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNURUsxMVA4OVlYQTAxT1VLRVpOU1o1MFFDVy4u"
+                    "surveyLink": "https://forms.office.com/Pages/ResponsePage.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNURUsxMVA4OVlYQTAxT1VLRVpOU1o1MFFDVy4u"
                 },
                 "Podcasts": {
                     "id": "6.1.3",
                     "label": "Podcasts",
                     "path": "Podcasts",
-                    "surveyLink": "https://forms.office.com/pages/designpagev2.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNUNllQWFpVT0FDTkhJMUxNTU9FSFI5S08yVi4u"
+                    "surveyLink": "https://forms.office.com/Pages/ResponsePage.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNUNllQWFpVT0FDTkhJMUxNTU9FSFI5S08yVi4u"
                 }
             }
         },
@@ -350,12 +350,14 @@
                 "News Articles": {
                     "id": "6.2.1",
                     "label": "News Articles",
-                    "path": "NewsArchives"
+                    "path": "NewsArchives",
+                    "surveyLink": "https://forms.office.com/Pages/ResponsePage.aspx?id=SNwgxlAdUkmLOd9NVNdNgksLeUGJ_vlDujipnPAHzqlUQjU5WVc3UkQxVUNHRUIyS1lQVlQ4N0lGWiQlQCN0PWcu"
                 },
                 "Blogs": {
                     "id": "6.2.2",
                     "label": "Blogs",
-                    "path": "BlogArchives"
+                    "path": "BlogArchives",
+                    "surveyLink": "https://forms.office.com/Pages/ResponsePage.aspx?id=SNwgxlAdUkmLOd9NVNdNgtdpBcyuIGlPo5G4BrphEpNURUsxMVA4OVlYQTAxT1VLRVpOU1o1MFFDVy4u"
                 }
             }
         }

--- a/src/components/NewsModule.vue
+++ b/src/components/NewsModule.vue
@@ -76,7 +76,8 @@
             </nav>
           </div>
         </main>
-        <SurveyLinkComponent :surveyLink="cvenavs['AllNews']['surveyLink']" />
+        <SurveyLinkComponent v-if="newsPageInfo.newsType == 'all'" :surveyLink="cvenavs['AllNews']['surveyLink']" />
+        <SurveyLinkComponent v-else :surveyLink="cvenavs['AllNews']['submenu']['Recent']['submenu'][newsPageInfo.label]['surveyLink']" />
       </div>
       <div class="column is-3 is-hidden-touch">
         <NavigationSidebar :nav="cvenavs['AllNews']" />

--- a/src/views/Media/News/BlogArchives.vue
+++ b/src/views/Media/News/BlogArchives.vue
@@ -60,6 +60,7 @@
             <p class="cve-help-text">
               *Note: Additional archives will be added soon.
             </p>
+            <SurveyLinkComponent :surveyLink="cvenavs['AllNews']['submenu']['Archives']['submenu']['Blogs']['surveyLink']" />
           </div>
         </main>
       </div>
@@ -72,12 +73,14 @@
 
 <script>
 import NavigationSidebar from '@/components/NavigationSidebar.vue';
+import SurveyLinkComponent from '@/components/SurveyLinkComponent.vue';
 import newsData from '@/assets/data/news.json';
 
 export default {
   name: 'BlogArchives',
   components: {
     NavigationSidebar,
+    SurveyLinkComponent,
   },
   data() {
     return {

--- a/src/views/Media/News/Blogs.vue
+++ b/src/views/Media/News/Blogs.vue
@@ -19,6 +19,8 @@ export default {
         newsType: 'blog',
         id: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].id,
         label: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].label,
+        path: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].path,
+        surveyLink: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].surveyLink,
       },
       cveNavs: this.cvenavs,
     };

--- a/src/views/Media/News/News.vue
+++ b/src/views/Media/News/News.vue
@@ -17,6 +17,8 @@ export default {
         newsType: 'news',
         id: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].id,
         label: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].label,
+        path: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].path,
+        surveyLink: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].surveyLink,
       },
       cveNavs: this.cvenavs,
     };

--- a/src/views/Media/News/NewsArchives.vue
+++ b/src/views/Media/News/NewsArchives.vue
@@ -17,6 +17,7 @@
                 </li>
               </ul>
             </div>
+            <SurveyLinkComponent :surveyLink="cvenavs['AllNews']['submenu']['Archives']['submenu']['News Articles']['surveyLink']" />
           </div>
         </main>
       </div>
@@ -29,12 +30,14 @@
 
 <script>
 import NavigationSidebar from '@/components/NavigationSidebar.vue';
+import SurveyLinkComponent from '@/components/SurveyLinkComponent.vue';
 import newsData from '@/assets/data/news.json';
 
 export default {
   name: 'NewsArchives',
   components: {
     NavigationSidebar,
+    SurveyLinkComponent,
   },
   data() {
     return {

--- a/src/views/Media/News/NewsItem.vue
+++ b/src/views/Media/News/NewsItem.vue
@@ -71,6 +71,7 @@
             </div>
           </div>
         </main>
+        <SurveyLinkComponent :surveyLink="cvenavs['AllNews']['submenu']['Recent']['submenu'][`${submenuName}s`]['surveyLink']" />
       </div>
       <div class="column is-3 is-hidden-touch">
         <NavigationSidebar :nav="cvenavs['AllNews']" />
@@ -81,6 +82,7 @@
 
 <script>
 import NavigationSidebar from '@/components/NavigationSidebar.vue';
+import SurveyLinkComponent from '@/components/SurveyLinkComponent.vue';
 import newsData from '@/assets/data/news.json';
 import newsMixins from '@/mixins/newsMixins';
 
@@ -89,6 +91,14 @@ export default {
   mixins: [newsMixins],
   components: {
     NavigationSidebar,
+    SurveyLinkComponent,
+  },
+  data() {
+    const { newsType } = this.$route.params;
+    return {
+      submenuName: newsType === 'news' ? 'News Article' : newsType.charAt(0).toUpperCase() + newsType.substring(1),
+      cveNavs: this.cvenavs,
+    };
   },
   computed: {
     newsItem() {

--- a/src/views/Media/News/Podcasts.vue
+++ b/src/views/Media/News/Podcasts.vue
@@ -19,6 +19,8 @@ export default {
         newsType: 'podcast',
         id: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].id,
         label: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].label,
+        path: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].path,
+        surveyLink: this.cvenavs.AllNews.submenu.Recent.submenu[submenuName].surveyLink,
       },
       cveNavs: this.cvenavs,
     };


### PR DESCRIPTION
Please test all news-related pages: 1) that the survey link is present and 2) it goes to the corresponding MS form survey link.