### PR TITLE
Update the URLS for CNA-2020-0030 to point to most recently updated ones

### DIFF
--- a/src/assets/data/CNAsList.json
+++ b/src/assets/data/CNAsList.json
@@ -1587,7 +1587,7 @@
       {
         "label": "Policy",
         "language": "",
-        "url": "https://docs.craftercms.org/en/3.2/security/security-policies.html"
+        "url": "https://docs.craftercms.org/en/4.0/security/security-policies.html"
       }
     ],
     "securityAdvisories": {
@@ -1595,7 +1595,7 @@
       "advisories": [
         {
           "label": "Advisories",
-          "url": "https://docs.craftercms.org/en/3.2/security/advisory.html"
+          "url": "https://docs.craftercms.org/en/4.0/security/advisory.html"
         }
       ]
     },


### PR DESCRIPTION
Please see: [Issue 1684 ](https://github.com/CVEProject/cve-website/issues/1684)

This PR updates the URLS associated with `CNA-2020-0030` from the 3.2 -> 4.0 versions. The previous 3.2 urls were returning AccessDenied.