### PR TITLE
Show new lines in CVE descriptions in PublishedRecord

### DIFF
--- a/src/views/CVERecord/PublishedRecord.vue
+++ b/src/views/CVERecord/PublishedRecord.vue
@@ -80,7 +80,7 @@
       </div>
     </div>
     <div id="cve-desciption" class="content has-text-justified">
-      <p v-for="description in cveFieldList.descriptions" :key="description">{{description}}</p>
+      <p v-for="description in cveFieldList.descriptions" :key="description" style="white-space: pre">{{description}}</p>
     </div>
     <div id="cve-product-status-container" class="content">
       <h2 class="title is-size-5">Product Status</h2>


### PR DESCRIPTION
This will make \n in CVE descriptions visible on the CVE website