### PR TITLE
Fix typo on CNAsList.json

### DIFF
--- a/src/assets/data/CNAsList.json
+++ b/src/assets/data/CNAsList.json
@@ -7801,7 +7801,7 @@
         "Vendor"
       ],
       "TLR": {
-        "shortName": "cISA",
+        "shortName": "CISA",
         "organizationName": "Cybersecurity and Infrastructure Security Agency (CISA)"
       },
       "roles": [


### PR DESCRIPTION
Not super sure where this list is compiled from, but one CNA incorrectly lists "cISA" rather than "CISA" as its TLR.