### PR TITLE
Resolves #2938 Redesign and simplify glossary table

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,8 @@ export default {
 
 
 <style lang="scss">
+@import './assets/style/globals';
+
 #cve-skip-link {
   background-color: white;
   text-decoration: underline;

--- a/src/assets/data/glossaryEntries.json
+++ b/src/assets/data/glossaryEntries.json
@@ -1,140 +1,158 @@
 [
-	{
-	"id": "glossaryCoR",
-	"term": "Council of Roots",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCoR",
-	"definition": "The group of <span class='cve-term-reference'>TL-Roots</span> responsible for governance and administration of their respective hierarchies."
-	},
     {
-	"id": "glossaryCVE",
-	"term": "CVE",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVE",
-	"definition": "The CVE registered trademark and the name Common Vulnerabilities and Exposures."
+        "id": "glossaryCoR",
+        "term": "Council of Roots",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCoR",
+        "definition": "The group of <span class='cve-term-reference'>TL-Roots</span> responsible for governance and administration of their respective hierarchies."
     },
     {
-	"id": "glossaryBoard",
-	"term": "CVE Board",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryBoard",
-	"definition": "The organization responsible for the strategic direction, governance, operational structure, policies, and rules of the <span class='cve-term-reference'>CVE Program</span>."
+        "id": "glossaryCVE",
+        "term": "CVE",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVE",
+        "definition": "The CVE registered trademark and the name Common Vulnerabilities and Exposures."
     },
     {
-	"id": "glossaryCVEID",
-	"term": "CVE Identifier (CVE ID)",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVEID",	
-	"definition": "An alphanumeric string that identifies a Publicly Disclosed vulnerability. The format of the CVE ID is defined in the <span class='cve-term-reference'>CVE Record Format</span>."
+        "id": "glossaryBoard",
+        "term": "CVE Board",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryBoard",
+        "definition": "The organization responsible for the strategic direction, governance, operational structure, policies, and rules of the <span class='cve-term-reference'>CVE Program</span>."
     },
     {
-	"id": "glossaryCVEList",
-	"term": "CVE List",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVEList",
-	"definition": "The catalog of all published <span class='cve-term-reference'>CVE Records</span>."
+        "id": "glossaryCVEID",
+        "term": "CVE Identifier (CVE ID)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVEID",
+        "definition": "An alphanumeric string that identifies a Publicly Disclosed vulnerability. The format of the CVE ID is defined in the <span class='cve-term-reference'>CVE Record Format</span>."
     },
     {
-	"id": "glossaryCNA",
-	"term": "CVE Numbering Authority (CNA)",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCNA",
-	"definition": "An authorized entity with specific scope and responsibility to regularly assign <span class='cve-term-reference'>CVE IDs</span> and publish corresponding <span class='cve-term-reference'>CVE Records</span>."
+        "id": "glossaryCVEList",
+        "term": "CVE List",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVEList",
+        "definition": "The catalog of all published <span class='cve-term-reference'>CVE Records</span>."
     },
     {
-	"id": "glossaryCNALR",
-	"term": "CVE Numbering Authority of Last Resort (CNA-LR)",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCNALR",
-	"definition": "A CNA authorized by a <span class='cve-term-reference'>Root</span> to assign <span class='cve-term-reference'>CVE IDs</span> and to publish corresponding <span class='cve-term-reference'>CVE Records</span> within that Root’s scope for vulnerabilities not covered by the Scope of another CNA."
+        "id": "glossaryCNA",
+        "term": "CVE Numbering Authority (CNA)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCNA",
+        "definition": "An authorized entity with specific scope and responsibility to regularly assign <span class='cve-term-reference'>CVE IDs</span> and publish corresponding <span class='cve-term-reference'>CVE Records</span>."
     },
     {
-	"id": "glossaryProgram",
-	"term": "CVE Program",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryProgram",
-	"definition": "An international, community-driven effort to identify and catalog publicly disclosed <span class='cve-term-reference'>vulnerabilities</span>."
+        "id": "glossaryCNALR",
+        "term": "CVE Numbering Authority of Last Resort (CNA-LR)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCNALR",
+        "definition": "A CNA authorized by a <span class='cve-term-reference'>Root</span> to assign <span class='cve-term-reference'>CVE IDs</span> and to publish corresponding <span class='cve-term-reference'>CVE Records</span> within that Root’s scope for vulnerabilities not covered by the Scope of another CNA."
     },
     {
-	"id": "glossaryRecord",
-	"term": "CVE Record",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryRecord",
-	"definition": "Structured data about a Vulnerability associated with a CVE ID. CVE Records are authored by CNAs. A CVE Record can be in one of the following states:<ul class='cve-term-definition-list'><li><span class='cve-term-reference'><strong>Reserved</strong></span>: A CNA has reserved a CVE ID. This is the initial state of a CVE ID.</li><li><span class='cve-term-reference'><strong>Published</strong></span>: A CNA has populated the data associated with the CVE ID and published the CVE Record.</li><li><span class='cve-term-reference'><strong>Rejected</strong></span>: The CVE ID and the associated CVE Record should no longer be used. A Rejected CVE Record remains on the CVE List so that users know that the CVE ID and CVE Record are invalid.</li></ul>"
+        "id": "glossaryProgram",
+        "term": "CVE Program",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryProgram",
+        "definition": "An international, community-driven effort to identify and catalog publicly disclosed <span class='cve-term-reference'>vulnerabilities</span>."
     },
     {
-	"id": "glossaryWG",
-	"term": "CVE Working Group",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryWG",
-	"definition": "An organization created and administered by the <span class='cve-term-reference'>CVE Board</span> to accomplish specific objectives through collaboration with CVE stakeholders and the general public where appropriate."
+        "id": "glossaryRecord",
+        "term": "CVE Record",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryRecord",
+        "definition": "Structured data about a Vulnerability associated with a CVE ID. CVE Records are authored by CNAs. A CVE Record can be in one of the following states:<ul class='cve-term-definition-list'><li><span class='cve-term-reference'><strong>Reserved</strong></span>: A CNA has reserved a CVE ID. This is the initial state of a CVE ID.</li><li><span class='cve-term-reference'><strong>Published</strong></span>: A CNA has populated the data associated with the CVE ID and published the CVE Record.</li><li><span class='cve-term-reference'><strong>Rejected</strong></span>: The CVE ID and the associated CVE Record should no longer be used. A Rejected CVE Record remains on the CVE List so that users know that the CVE ID and CVE Record are invalid.</li></ul>"
     },
     {
-	"id": "glossaryEOL",
-	"term": "End of Life (EOL)",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryEOL",
-	"definition": "A <span class='cve-term-reference'>Product</span> that no longer receives security <span class='cve-term-reference'>Fixes</span>. EOL typically indicates that a Product no longer receives any support, maintenance, or new features."
-	},
-    {
-	"id": "glossaryFix",
-	"term": "Fix",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryFix",
-	"definition": "A change to software to remediate, mitigate, or otherwise address a vulnerability. “Fix” is used broadly and includes terms such as patch, fix, hotfix, update, and upgrade."
-	},
-    {
-	"id": "glossaryIndependentlyFixable",
-	"term": "Independently Fixable",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryIndependentlyFixable",
-	"definition": "A vulnerability is independently fixable when it can be fixed without fixing a separate vulnerability."
-	},
-    {
-	"id": "glossaryProduct",
-	"term": "Product",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryProduct",
-	"definition": "A unit of software or hardware or both. “Product” is used broadly and includes services, open source projects, specifications, and other common terms such as: system, appliance, device, component, library, package, archive, and collection."
-	},
-	{
-	"id": "glossaryPubliclyDisclosed",
-	"term": "Publicly Disclosed",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryPubliclyDisclosed",
-	"definition": "The state in which non-trivial information about a vulnerability is publicly available. The publication of most vulnerability advisories, software updates, proof-of-concept exploit code, or other detailed information makes the vulnerability “Publicly Disclosed.”"
-	},
-    {
-	"id": "glossaryRBP",
-	"term": "Reserved but Public (RBP)",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryRBP",
-	"definition": "A CVE ID in the “<span class='cve-term-reference'>Reserved</span>” state that is referenced in one or more public sources but for which a <span class='cve-term-reference'>CVE Record</span> has not been published."
+        "id": "glossaryWG",
+        "term": "CVE Working Group",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryWG",
+        "definition": "An organization created and administered by the <span class='cve-term-reference'>CVE Board</span> to accomplish specific objectives through collaboration with CVE stakeholders and the general public where appropriate."
     },
     {
-	"id": "glossaryRoot",
-	"term": "Root",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryRoot",
-	"definition": "An organization authorized within the <span class='cve-term-reference'>CVE Program</span> that is responsible, within a specific Scope, for the recruitment, training, and governance of one or more entities that are a <span class='cve-term-reference'>CNA</span>, <span class='cve-term-reference'>CNA-LR</span>, or another Root."
+        "id": "glossaryEOL",
+        "term": "End of Life (EOL)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryEOL",
+        "definition": "The entity that develops, maintains, or provides a product regardless of whether the product is an open-source project or a proprietary product. A supplier is typically responsible for and capable of investigating vulnerability reports and developing fixes or mitigations for vulnerabilities. “Supplier” is used broadly and includes common terms such as vendor, producer, developer, maintainer, author, owner, manufacturer, and provider."
     },
     {
-	"id": "glossaryScope",
-	"term": "Scope",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryScope",
-	"definition": "A defined set of products, vulnerabilities, or both for which a <span class='cve-term-reference'>CNA</span> has authority and responsibility."
+        "id": "glossaryFix",
+        "term": "Fix",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryFix",
+        "definition": "A change to software to remediate, mitigate, or otherwise address a vulnerability. “Fix” is used broadly and includes terms such as patch, fix, hotfix, update, and upgrade."
     },
     {
-	"id": "glossarySecretariat",
-	"term": "Secretariat",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossarySecretariat",
-	"definition": "An organization authorized by the <span class='cve-term-reference'>CVE Program</span> to develop, host, and maintain the Program’s infrastructure and to provide administrative and logistical support for the <span class='cve-term-reference'>CVE Board</span>, <span class='cve-term-reference'>CVE Working Groups</span>, and other parts of the Program."
+        "id": "glossaryIndependentlyFixable",
+        "term": "Independently Fixable",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryIndependentlyFixable",
+        "definition": "A vulnerability is independently fixable when it can be fixed without fixing a separate vulnerability."
     },
     {
-	"id": "glossarySupplier",
-	"term": "Supplier",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossarySupplier",
-	"definition": "The entity that develops, maintains, or provides a product. A supplier is typically responsible for and capable of investigating vulnerability reports and developing fixes or mitigations for vulnerabilities. “Supplier” is used broadly and includes common terms such as vendor, producer, developer, maintainer, author, owner, manufacturer, and provider."
-	},
-    {
-	"id": "glossaryTags",
-	"term": "Tags",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryTags",
-	"definition": "Labels used to indicate defined characteristics of CVE IDs: <ul class='cve-term-definition-list'><li><strong>exclusively-hosted-service</strong>: All known Products affected by the CVE ID exist only as fully hosted services. If the vulnerability affects both hosted services and on-premises Products, then this tag should not be used.</li><li><strong>unsupported-when-assigned</strong>: At the time of CVE ID assignment, all known Products affected by the CVE ID no longer receive security Fixes. Typically, the Products are no longer supported and are considered to be End of Life (EOL).</li><li><strong>disputed</strong>: A CVE ID assignment or CVE Record content have been disputed.</li></ul>"
-	},
-    {
-	"id": "glossaryTLRoot",
-	"term": "Top-Level Root (TL-Root)",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryTLRoot",
-	"definition": "A <span class='cve-term-reference'>Root</span> that is responsible for the governance and administration of its hierarchy, including <span class='cve-term-reference'>Roots</span> and <span class='cve-term-reference'>CNAs</span> within that hierarchy."
+        "id": "glossaryProduct",
+        "term": "Product",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryProduct",
+        "definition": "A unit of software or hardware or both. “Product” is used broadly and includes services, open source projects, specifications, and other common terms such as: system, appliance, device, component, library, package, archive, and collection."
     },
     {
-	"id": "glossaryVulnerability",
-	"term": "Vulnerability",
-	"termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryVulnerability",
-	"definition": "An instance of one or more weaknesses in a Product that can be exploited, causing a negative impact to confidentiality, integrity, or availability; a set of conditions or behaviors that allows the violation of an explicit or implicit security policy."
+        "id": "glossaryPubliclyDisclosed",
+        "term": "Publicly Disclosed",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryPubliclyDisclosed",
+        "definition": "The state in which non-trivial information about a vulnerability is publicly available. The publication of most vulnerability advisories, software updates, proof-of-concept exploit code, or other detailed information makes the vulnerability “Publicly Disclosed.”"
+    },
+    {
+        "id": "glossaryRBP",
+        "term": "Reserved but Public (RBP)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryRBP",
+        "definition": "A CVE ID in the “<span class='cve-term-reference'>Reserved</span>” state that is referenced in one or more public sources but for which a <span class='cve-term-reference'>CVE Record</span> has not been published."
+    },
+    {
+        "id": "glossaryRoot",
+        "term": "Root",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryRoot",
+        "definition": "An organization authorized within the <span class='cve-term-reference'>CVE Program</span> that is responsible, within a specific Scope, for the recruitment, training, and governance of one or more entities that are a <span class='cve-term-reference'>CNA</span>, <span class='cve-term-reference'>CNA-LR</span>, or another Root."
+    },
+    {
+        "id": "glossaryScope",
+        "term": "Scope",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryScope",
+        "definition": "A defined set of products, vulnerabilities, or both for which a <span class='cve-term-reference'>CNA</span> has authority and responsibility."
+    },
+    {
+        "id": "glossarySecretariat",
+        "term": "Secretariat",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossarySecretariat",
+        "definition": "An organization authorized by the <span class='cve-term-reference'>CVE Program</span> to develop, host, and maintain the Program’s infrastructure and to provide administrative and logistical support for the <span class='cve-term-reference'>CVE Board</span>, <span class='cve-term-reference'>CVE Working Groups</span>, and other parts of the Program."
+    },
+    {
+        "id": "glossarySupplier",
+        "term": "Supplier",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossarySupplier",
+        "definition": "The entity that develops, maintains, or provides a product regardless of whether the product is an open-source project or a proprietary product. A supplier is typically responsible for and capable of investigating vulnerability reports and developing fixes or mitigations for vulnerabilities. “Supplier” is used broadly and includes common terms such as vendor, producer, developer, maintainer, author, owner, manufacturer, and provider."
+    },
+    {
+        "id": "glossaryTags",
+        "term": "Tags",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryTags",
+        "definition": "Labels used to indicate defined characteristics of CVE IDs: <ul class='cve-term-definition-list'><li><strong>exclusively-hosted-service</strong>: All known Products affected by the CVE ID exist only as fully hosted services. If the vulnerability affects both hosted services and on-premises Products, then this tag should not be used.</li><li><strong>unsupported-when-assigned</strong>: At the time of CVE ID assignment, all known Products affected by the CVE ID no longer receive security Fixes. Typically, the Products are no longer supported and are considered to be End of Life (EOL).</li><li><strong>disputed</strong>: A CVE ID assignment or CVE Record content have been disputed.</li></ul>"
+    },
+    {
+        "id": "glossaryTLRoot",
+        "term": "Top-Level Root (TL-Root)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryTLRoot",
+        "definition": "The highest-level <span class='cve-term-reference'>Root</span> responsible for the governance and administration of a specified hierarchy, including <span class='cve-term-reference'>Roots</span> and <span class='cve-term-reference'>CNAs</span> within that hierarchy."
+    },
+    {
+        "id": "glossaryVulnerability",
+        "term": "Vulnerability",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryVulnerability",
+        "definition": "An instance of one or more weaknesses in a Product that can be exploited, causing a negative impact to confidentiality, integrity, or availability; a set of conditions or behaviors that allows the violation of an explicit or implicit security policy."
+    },
+    {
+        "id": "glossaryCVEParticipants",
+        "term": "CVE Program Participants",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryCVEParticipants",
+        "definition": "Anyone who is an active participant in the CVE Program, including CVE Board members, CNAs, Authorized Data Publishers (ADPs), and the CVE Program Secretariat."
+    },
+    {
+        "id": "glossaryReporter",
+        "term": "Reporter",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryReporter",
+        "definition": "The entity that reports a vulnerability to a CNA. It could be a security researcher, a corporate partner, an end-user, etc."
+    },
+    {
+        "id": "glossaryADP",
+        "term": "Authorized Data Publisher (ADP)",
+        "termLink": "/ResourcesSupport/Glossary?activeTerm=glossaryADP",
+        "definition": "An authorized entity with specific scope and responsibility to enrich the content of CVE Records published by CVE Numbering Authorities (CNAs) with additional, pertinent information (e.g., risk scores, references, vulnerability characteristics, translations)."
     }
 ]

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -80,10 +80,10 @@
   @import '@/assets/style/routerLink.scss';
 
   @media only screen and (min-width: $desktop) {
-  .table-column-width {
-    width: 30%;
+    .table-column-width {
+      width: 30% !important;
+    }
   }
- }
 
  .cve-term-active {
   background-color: $theme-color-accent-cool-light !important;
@@ -93,9 +93,9 @@
   padding-bottom: 5px;
 }
   
-  .termLink {
-    color: $theme-color-primary;
-  }
+.termLink {
+  color: $theme-color-primary;
+}
 
   .selectTermLink {
     color: black;

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,5 +1,5 @@
 <template>
-     <div class="table-container">
+     <div ref="tableRef" class="table-container">
               <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
                 <caption class="cve-help-text">* Select the glossary term to copy or save the link.</caption>
                 <thead>
@@ -10,17 +10,19 @@
                 <tbody>
                   <tr v-for="(entry, index) in tableData" :key="index"
                     :id="entry.id"
+                    :ref="entry.id"
                     v-on:click="selectRow(entry.id)"
                     
                     v-bind:class="{'cve-term-active': selectedRow === entry.id}">
                     <td class="table-column-width">
-                        <a href="#" class="has-text-weight-bold"> {{ entry.term }} </a>*
+                        <a :href="entry.termLink" class="has-text-weight-bold"> {{ entry.term }} </a>*
                     </td>
                     <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
                     <td v-else class="cve-term-definition">{{ entry.definition }} </td>
                   </tr>
                 </tbody>
             </table>
+            <div ref="test"> Hello here is a test</div>
             </div>
   </template>
   
@@ -45,8 +47,25 @@
     },
     data() {
       return {
-       selectedRow: null
+       selectedRow: null 
       };
+    },
+    mounted() {
+        let term = null;
+
+         // Add active term as a hash to scroll to it then select it
+        if (this.$route.query.activeTerm) {
+             term = this.$route.query.activeTerm;
+             this.$router.push({hash: "#" + term })
+             this.selectRow(term)
+        }
+        // If route already has a hash, just select the term
+        else if (this.$route.hash) {
+             term = this.$route.hash.slice(1);
+             this.selectRow(term)
+        }
+       
+      
     },
     methods: {
         selectRow(rowId) {
@@ -71,10 +90,10 @@
  .cve-term-active {
   background-color: $theme-color-accent-cool-light !important;
   color: black;
-  padding-left: 8px;
+  padding-left: 8px; 
   padding-top: 5px;
   padding-bottom: 5px;
 }
   
 </style>
-  
+   

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,6 +1,5 @@
 <template>
      <div class="table-container">
-        <!-- <DataTable :data="tableData" :columns="tableHeaders" aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" > -->
               <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
                 <caption class="cve-help-text">* Select the glossary term to copy or save the link.</caption>
                 <thead>
@@ -11,9 +10,11 @@
                 <tbody>
                   <tr v-for="(entry, index) in tableData" :key="index"
                     :id="entry.id"
-                    v-bind:class="{'cve-term-active': isActive == entry.id}">
+                    v-on:click="selectRow(entry.id)"
+                    
+                    v-bind:class="{'cve-term-active': selectedRow === entry.id}">
                     <td class="table-column-width">
-                        <a :href="entry.termLink" class="has-text-weight-bold"> {{ entry.term }} </a>*
+                        <a href="#" class="has-text-weight-bold"> {{ entry.term }} </a>*
                     </td>
                     <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
                     <td v-else class="cve-term-definition">{{ entry.definition }} </td>
@@ -24,6 +25,7 @@
   </template>
   
   <script>
+
   export default {
     name: "SearchTable",
     props: {
@@ -43,30 +45,36 @@
     },
     data() {
       return {
-       
+       selectedRow: null
       };
     },
     methods: {
-   
+        selectRow(rowId) {
+          
+            this.selectedRow = (rowId === this.selectedRow ? null : rowId)
+        }
     },
   };
   </script>
   
   <!-- Add "scoped" attribute to limit CSS to this component only -->
-  <style scoped lang="scss">
+<style scoped lang="scss">
   
   @import '@/assets/style/routerLink.scss';
-//   @import 'datatables.net-dt';
-  .cve-menu-shift {
-    font-weight: bold;
-    padding-left: 12px;
-  }
 
   @media only screen and (min-width: $desktop) {
   .table-column-width {
     width: 30%;
   }
+ }
+
+ .cve-term-active {
+  background-color: $theme-color-accent-cool-light !important;
+  color: black;
+  padding-left: 8px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
   
-  </style>
+</style>
   

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,0 +1,79 @@
+<template>
+     <div class="table-container">
+              <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
+                <caption class="cve-help-text">* Select the glossary term to copy or save the link.</caption>
+                <thead>
+                  <tr>
+                    <th v-for="(header, index) in tableHeaders" :key="index" style="width: 30%">{{header}}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(entry, index) in tableData" :key="index"
+                    :id="entry.id"
+                    v-bind:class="{'cve-term-active': isActive == entry.id}">
+                    <td style="width: 30%">
+                        <a :href="entry.termLink" class="has-text-weight-bold"> {{ entry.term }} </a>*
+                    </td>
+                    <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
+                    <td v-else class="cve-term-definition">{{ entry.definition }} </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+  </template>
+  
+  <script>
+  
+  export default {
+    name: "SearchTable",
+    props: {
+      tableData: {
+        type: Array,
+        required: true,
+      },
+      tableHeaders: {
+        type: Array,
+        required: true,
+      },
+      renderAsHTML: {
+        type: Boolean,
+        default: false,
+        required: false,
+      }
+    },
+    data() {
+      return {
+       
+      };
+    },
+    methods: {
+    //   toggleSubmenuItem(path) {
+    //     if (this.selectedSubmenu.includes(path)) {
+    //       const index = this.selectedSubmenu.indexOf(path);
+    //       this.selectedSubmenu.splice(index, 1);
+    //     } else {
+    //       this.selectedSubmenu.push(path);
+    //     }
+    //   },
+    //   getAdjustedPath(path) {
+    //     return (this.$route.fullPath.includes('/Media/News/item')) ? `/Media/News/${path}` : path;
+    //   },
+    //   isExactPath(onPageLink) {
+    //     return useLinkStore().isExactPath(onPageLink, this.$route.fullPath);
+    //   }
+    },
+  };
+  </script>
+  
+  <!-- Add "scoped" attribute to limit CSS to this component only -->
+  <style scoped lang="scss">
+  @import '@/assets/style/globals.scss';
+  @import '@/assets/style/routerLink.scss';
+  
+  .cve-menu-shift {
+    font-weight: bold;
+    padding-left: 12px;
+  }
+  
+  </style>
+  

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,27 +1,27 @@
 <template>
-     <div ref="tableRef" class="table-container">
-        <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
-          <thead>
-            <tr>
-              <th v-for="(header, index) in tableHeaders" :key="index">{{header}}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(entry, index) in tableData" :key="index"
-              :id="entry.id"
-              :ref="entry.id"
-              v-on:click="selectRow(entry.id)"
-              
-              v-bind:class="{'cve-term-active': selectedRow === entry.id}">
-              <td class="table-column-width">
-                  <a :href="entry.termLink" v-bind:class="{'selectTermLink': selectedRow === entry.id}" class="has-text-weight-bold termLink"> {{ entry.term }} </a>
-              </td>
-              <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
-              <td v-else class="cve-term-definition">{{ entry.definition }} </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+  <div ref="tableRef" class="table-container">
+    <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
+      <thead>
+        <tr>
+          <th v-for="(header, index) in tableHeaders" :key="index">{{header}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(entry, index) in tableData" :key="index"
+          :id="entry.id"
+          :ref="entry.id"
+          v-on:click="selectRow(entry.id)"
+          
+          v-bind:class="{'cve-term-active': selectedRow === entry.id}">
+          <td class="table-column-width">
+              <a :href="entry.termLink" v-bind:class="{'selectTermLink': selectedRow === entry.id}" class="has-text-weight-bold termLink"> {{ entry.term }} </a>
+          </td>
+          <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
+          <td v-else class="cve-term-definition">{{ entry.definition }} </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
   </template>
   
   <script>
@@ -49,27 +49,25 @@
       };
     },
     mounted() {
-        let term = null;
+      let term = null;
 
-         // Add active term as a hash to scroll to it then select it
-        if (this.$route.query.activeTerm) {
-             term = this.$route.query.activeTerm;
-             this.$router.push({hash: "#" + term })
-             this.selectRow(term)
-        }
-        // If route already has a hash, just select the term
-        else if (this.$route.hash) {
-             term = this.$route.hash.slice(1);
-             this.selectRow(term)
-        }
-       
-      
+        // Add active term as a hash to scroll to it then select it
+      if (this.$route.query.activeTerm) {
+            term = this.$route.query.activeTerm;
+            this.$router.push({hash: "#" + term })
+            this.selectRow(term)
+      }
+      // If route already has a hash, just select the term
+      else if (this.$route.hash) {
+            term = this.$route.hash.slice(1);
+            this.selectRow(term)
+      }
     },
     methods: {
-        selectRow(rowId) {
-          
-            this.selectedRow = (rowId === this.selectedRow ? null : rowId)
-        }
+      selectRow(rowId) {
+        
+          this.selectedRow = (rowId === this.selectedRow ? null : rowId)
+      }
     },
   };
   </script>
@@ -77,15 +75,15 @@
   <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
   
-  @import '@/assets/style/routerLink.scss';
+@import '@/assets/style/routerLink.scss';
 
-  @media only screen and (min-width: $desktop) {
-    .table-column-width {
-      width: 30% !important;
-    }
+@media only screen and (min-width: $desktop) {
+  .table-column-width {
+    width: 30% !important;
   }
+}
 
- .cve-term-active {
+.cve-term-active {
   background-color: $theme-color-accent-cool-light !important;
   color: black ;
   padding-left: 8px; 
@@ -97,8 +95,8 @@
   color: $theme-color-primary;
 }
 
-  .selectTermLink {
-    color: black;
-  }
+.selectTermLink {
+  color: black;
+}
 </style>
    

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,29 +1,29 @@
 <template>
      <div class="table-container">
+        <!-- <DataTable :data="tableData" :columns="tableHeaders" aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" > -->
               <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
                 <caption class="cve-help-text">* Select the glossary term to copy or save the link.</caption>
                 <thead>
                   <tr>
-                    <th v-for="(header, index) in tableHeaders" :key="index" style="width: 30%">{{header}}</th>
+                    <th v-for="(header, index) in tableHeaders" :key="index">{{header}}</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr v-for="(entry, index) in tableData" :key="index"
                     :id="entry.id"
                     v-bind:class="{'cve-term-active': isActive == entry.id}">
-                    <td style="width: 30%">
+                    <td class="table-column-width">
                         <a :href="entry.termLink" class="has-text-weight-bold"> {{ entry.term }} </a>*
                     </td>
                     <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
                     <td v-else class="cve-term-definition">{{ entry.definition }} </td>
                   </tr>
                 </tbody>
-              </table>
+            </table>
             </div>
   </template>
   
   <script>
-  
   export default {
     name: "SearchTable",
     props: {
@@ -47,33 +47,26 @@
       };
     },
     methods: {
-    //   toggleSubmenuItem(path) {
-    //     if (this.selectedSubmenu.includes(path)) {
-    //       const index = this.selectedSubmenu.indexOf(path);
-    //       this.selectedSubmenu.splice(index, 1);
-    //     } else {
-    //       this.selectedSubmenu.push(path);
-    //     }
-    //   },
-    //   getAdjustedPath(path) {
-    //     return (this.$route.fullPath.includes('/Media/News/item')) ? `/Media/News/${path}` : path;
-    //   },
-    //   isExactPath(onPageLink) {
-    //     return useLinkStore().isExactPath(onPageLink, this.$route.fullPath);
-    //   }
+   
     },
   };
   </script>
   
   <!-- Add "scoped" attribute to limit CSS to this component only -->
   <style scoped lang="scss">
-  @import '@/assets/style/globals.scss';
-  @import '@/assets/style/routerLink.scss';
   
+  @import '@/assets/style/routerLink.scss';
+//   @import 'datatables.net-dt';
   .cve-menu-shift {
     font-weight: bold;
     padding-left: 12px;
   }
+
+  @media only screen and (min-width: $desktop) {
+  .table-column-width {
+    width: 30%;
+  }
+}
   
   </style>
   

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -22,7 +22,6 @@
                   </tr>
                 </tbody>
             </table>
-            <div ref="test"> Hello here is a test</div>
             </div>
   </template>
   

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,28 +1,27 @@
 <template>
      <div ref="tableRef" class="table-container">
-              <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
-                <caption class="cve-help-text">* Select the glossary term to copy or save the link.</caption>
-                <thead>
-                  <tr>
-                    <th v-for="(header, index) in tableHeaders" :key="index">{{header}}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="(entry, index) in tableData" :key="index"
-                    :id="entry.id"
-                    :ref="entry.id"
-                    v-on:click="selectRow(entry.id)"
-                    
-                    v-bind:class="{'cve-term-active': selectedRow === entry.id}">
-                    <td class="table-column-width">
-                        <a :href="entry.termLink" class="has-text-weight-bold"> {{ entry.term }} </a>*
-                    </td>
-                    <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
-                    <td v-else class="cve-term-definition">{{ entry.definition }} </td>
-                  </tr>
-                </tbody>
-            </table>
-            </div>
+        <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
+          <thead>
+            <tr>
+              <th v-for="(header, index) in tableHeaders" :key="index">{{header}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(entry, index) in tableData" :key="index"
+              :id="entry.id"
+              :ref="entry.id"
+              v-on:click="selectRow(entry.id)"
+              
+              v-bind:class="{'cve-term-active': selectedRow === entry.id}">
+              <td class="table-column-width">
+                  <a :href="entry.termLink" v-bind:class="{'selectTermLink': selectedRow === entry.id}" class="has-text-weight-bold termLink"> {{ entry.term }} </a>
+              </td>
+              <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
+              <td v-else class="cve-term-definition">{{ entry.definition }} </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
   </template>
   
   <script>
@@ -88,11 +87,18 @@
 
  .cve-term-active {
   background-color: $theme-color-accent-cool-light !important;
-  color: black;
+  color: black ;
   padding-left: 8px; 
   padding-top: 5px;
   padding-bottom: 5px;
 }
   
+  .termLink {
+    color: $theme-color-primary;
+  }
+
+  .selectTermLink {
+    color: black;
+  }
 </style>
    

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -48,7 +48,7 @@ const router = createRouter({
     if (to.hash) {
       return {
         el: to.hash,
-        top: 100
+        top: 55
       };
     }
     return {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -48,7 +48,7 @@ const router = createRouter({
     if (to.hash) {
       return {
         el: to.hash,
-        top: 55,
+        top: 100
       };
     }
     return {

--- a/src/views/ResourcesSupport/Glossary.vue
+++ b/src/views/ResourcesSupport/Glossary.vue
@@ -66,13 +66,8 @@ export default {
     },
   },
   mounted() {
-    if (this.$route.query.activeTerm) {
-      this.setDefinitionForActiveTerm(this.$route.query.activeTerm);
-    }
-
+    // Sort data before creating table
     this.glossaryEntries = _.sortBy(this.glossaryEntries, ['term'])
-
-
   },
 };
 </script>

--- a/src/views/ResourcesSupport/Glossary.vue
+++ b/src/views/ResourcesSupport/Glossary.vue
@@ -7,28 +7,10 @@
             <h1 :id="cvenavs['Resources & Support']['submenu']['Glossary']" class="title">
             {{cvenavs['Resources & Support']['submenu']['Glossary']['label']}}</h1>
             <div class="table-container">
-              <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
-                <caption class="cve-help-text">* Select the glossary term to copy or save the link.</caption>
-                <thead>
-                  <tr>
-                    <th style="width: 30%">Term</th>
-                    <th>Definition</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td style="width: 30%">
-                      <a :href="currentTermLink">
-                        <span class="has-text-weight-bold" v-html="currentTerm"></span>
-                      </a>*
-                    </td>
-                    <td><span v-html="currentDefinition" class="cve-term-definition"></span></td>
-                  </tr>
-                </tbody>
-              </table>
+              <search-table :table-headers="headers" :table-data="glossaryEntries" :renderAsHTML="true"></search-table>
             </div>
             <hr/>
-            <div class="cve-glossary-terms">
+            <!-- <div class="cve-glossary-terms">
               <div class="columns">
                 <div class="column">
                   <a href="#" class="cve-term-link"
@@ -47,7 +29,7 @@
                   </a>
                 </div>
               </div>
-            </div> <!-- end cve-glossary-terms -->
+            </div> end cve-glossary-terms -->
            </div>  <!-- end content -->
           <SurveyLinkComponent :surveyLink="cvenavs['Resources & Support']['submenu']['Glossary']['surveyLink']" />
           </main>
@@ -62,13 +44,16 @@
 <script>
 import NavigationSidebar from '@/components/NavigationSidebar.vue';
 import SurveyLinkComponent from '@/components/SurveyLinkComponent.vue';
+import SearchTable from '@/components/SearchTable.vue';
 import GlossaryData from '../../assets/data/glossaryEntries.json';
+
 
 export default {
   name: 'Glossary',
   components: {
     NavigationSidebar,
     SurveyLinkComponent,
+    SearchTable
   },
   props: {
     cvenavs: {
@@ -87,6 +72,7 @@ export default {
       currentTerm: GlossaryData[0].term,
       currentTermLink: GlossaryData[0].termLink,
       glossaryEntries: GlossaryData,
+      headers: ['Term', 'Definition']
     };
   },
   methods: {

--- a/src/views/ResourcesSupport/Glossary.vue
+++ b/src/views/ResourcesSupport/Glossary.vue
@@ -7,7 +7,7 @@
             <h1 :id="cvenavs['Resources & Support']['submenu']['Glossary']" class="title">
             {{cvenavs['Resources & Support']['submenu']['Glossary']['label']}}</h1>
             <div class="table-container">
-              <search-table :table-headers="headers" :table-data="glossaryEntries" :renderAsHTML="true"></search-table>
+              <SearchTable :table-headers="headers" :table-data="glossaryEntries" :renderAsHTML="true"></SearchTable>
             </div>
             <hr/>
             <!-- <div class="cve-glossary-terms">
@@ -94,7 +94,7 @@ export default {
 
 <!-- Cannot use "scoped" attribute with v-html above -->
 <style lang="scss">
-@import '../../assets/style/globals.scss';
+
 
 .cve-glossary-terms {
   text-align: left;

--- a/src/views/ResourcesSupport/Glossary.vue
+++ b/src/views/ResourcesSupport/Glossary.vue
@@ -10,26 +10,6 @@
               <SearchTable :table-headers="headers" :table-data="glossaryEntries" :renderAsHTML="true"></SearchTable>
             </div>
             <hr/>
-            <!-- <div class="cve-glossary-terms">
-              <div class="columns">
-                <div class="column">
-                  <a href="#" class="cve-term-link"
-                    v-for="(entry, index) in glossaryEntries.slice(0,glossaryEntries.length/2)" :key="index"
-                    :id="entry.id"
-                    v-bind:class="{'cve-term-active': isActive == entry.id}"
-                    v-on:click="setDefinitionForActiveTerm(entry.id)">{{entry.term}}
-                  </a>
-                </div>
-                <div class="column">
-                  <a href="#" class="cve-term-link"
-                    v-for="(entry, index) in glossaryEntries.slice(glossaryEntries.length/2)" :key="index"
-                    :id="entry.id"
-                    v-bind:class="{'cve-term-active': isActive == entry.id}"
-                    v-on:click="setDefinitionForActiveTerm(entry.id)">{{entry.term}}
-                  </a>
-                </div>
-              </div>
-            </div> end cve-glossary-terms -->
            </div>  <!-- end content -->
           <SurveyLinkComponent :surveyLink="cvenavs['Resources & Support']['submenu']['Glossary']['surveyLink']" />
           </main>
@@ -47,6 +27,7 @@ import SurveyLinkComponent from '@/components/SurveyLinkComponent.vue';
 import SearchTable from '@/components/SearchTable.vue';
 import GlossaryData from '../../assets/data/glossaryEntries.json';
 
+import _ from 'lodash'
 
 export default {
   name: 'Glossary',
@@ -88,13 +69,15 @@ export default {
     if (this.$route.query.activeTerm) {
       this.setDefinitionForActiveTerm(this.$route.query.activeTerm);
     }
+
+    this.glossaryEntries = _.sortBy(this.glossaryEntries, ['id'])
+
+
   },
 };
 </script>
 
-<!-- Cannot use "scoped" attribute with v-html above -->
 <style lang="scss">
-
 
 .cve-glossary-terms {
   text-align: left;
@@ -102,14 +85,6 @@ export default {
 
 .cve-term {
   font-weight: bold;
-}
-
-.cve-term-active {
-  background-color: $theme-color-accent-cool-light;
-  color: black;
-  padding-left: 8px;
-  padding-top: 5px;
-  padding-bottom: 5px;
 }
 
 .cve-term-link {

--- a/src/views/ResourcesSupport/Glossary.vue
+++ b/src/views/ResourcesSupport/Glossary.vue
@@ -70,7 +70,7 @@ export default {
       this.setDefinitionForActiveTerm(this.$route.query.activeTerm);
     }
 
-    this.glossaryEntries = _.sortBy(this.glossaryEntries, ['id'])
+    this.glossaryEntries = _.sortBy(this.glossaryEntries, ['term'])
 
 
   },


### PR DESCRIPTION
Closes #2938 

## Summary
Redesigned the Glossary page to show terms and definitions in a table view. Each term can be linked and will be scrolled to when links are accessed from other pages.

![Screenshot 2024-07-12 at 1 55 32 PM](https://github.com/user-attachments/assets/d1c9a830-dd4f-4654-bb42-a05132fbd809)
