### PR TITLE
Resolves #2931 Added `toFixed(1)` to CVSS score displays

### DIFF
--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -152,7 +152,7 @@ export default {
         }
 
         if (supportedCvssVersions.includes(cvssVersion)) {
-          if (metricObj[cvssVersion]?.baseScore || typeof metricObj[cvssVersion].baseScore === 'number') cvss.baseScore =  metricObj[cvssVersion].baseScore;
+          if (metricObj[cvssVersion]?.baseScore || typeof metricObj[cvssVersion].baseScore === 'number') cvss.baseScore =  metricObj[cvssVersion].baseScore.toFixed(1);
 
           if (metricObj[cvssVersion]?.baseSeverity) {
             if (metricObj[cvssVersion]?.baseSeverity) cvss.baseSeverity =  metricObj[cvssVersion].baseSeverity;


### PR DESCRIPTION
Closes #2931 

## Summary
Added `toFixed(1)` to CVSS scores shown on the CVE Record details page, as CVSS scores should always have 1 decimal place.

