### PR TITLE
Resolves #2932 Fixes title overflow in cnaContainer 

### DIFF
--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -569,7 +569,7 @@ label {
   overflow-x: auto
 }
 
-.w-100 {
+.cve-w-100 {
   width: 100%;
 }
 

--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -569,6 +569,10 @@ label {
   overflow-x: auto
 }
 
+.w-100 {
+  width: 100%;
+}
+
 /* Other ends here*/
 
 /* Third party CSS */

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -101,8 +101,8 @@
               </div>
             </nav>
             <nav v-if="cveFieldList.title.length > 0" id="cve-record-title-container" class="level mb-0">
-              <div class="level-left w-100">
-                <div class="level-item w-100 cve-title">
+              <div class="level-left cve-w-100">
+                <div class="level-item cve-w-100 cve-title">
                   <p class="mb-0">
                     <span class="has-text-weight-bold">Title: </span>
                     <span style="text-transform: capitalize;">{{ cveFieldList.title }}</span>

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -101,8 +101,8 @@
               </div>
             </nav>
             <nav v-if="cveFieldList.title.length > 0" id="cve-record-title-container" class="level mb-0">
-              <div class="level-left">
-                <div class="level-item">
+              <div class="level-left w-100">
+                <div class="level-item w-100">
                   <p class="mb-0">
                     <span class="has-text-weight-bold">Title: </span>
                     <span style="text-transform: capitalize;">{{ cveFieldList.title }}</span>

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -102,7 +102,7 @@
             </nav>
             <nav v-if="cveFieldList.title.length > 0" id="cve-record-title-container" class="level mb-0">
               <div class="level-left w-100">
-                <div class="level-item w-100">
+                <div class="level-item w-100 cve-title">
                   <p class="mb-0">
                     <span class="has-text-weight-bold">Title: </span>
                     <span style="text-transform: capitalize;">{{ cveFieldList.title }}</span>
@@ -443,5 +443,9 @@ export default {
 
   .cve-learn-more-link:hover, :focus {
     color: $theme-color-base-darker !important;
+  }
+
+  .cve-title {
+    justify-content: left;
   }
 </style>


### PR DESCRIPTION
## Summary
Fixed title text in cnaContainers so they wrap to a new line instead of overflowing out of the container.

![Screenshot 2024-08-20 at 12 46 58 PM](https://github.com/user-attachments/assets/ed062201-729e-4398-a5bd-d065f9bd6c0d)

![Screenshot 2024-08-21 at 1 23 38 PM](https://github.com/user-attachments/assets/56f8d794-c2b7-4b73-87ba-e4a22d339ccf)
