### PR TITLE
Resolves #3026 Sticky table headers and scrollbars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cve-website",
       "version": "0.1.0",
       "dependencies": {
+        "@cityssm/bulma-sticky-table": "^2.1.0",
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-brands-svg-icons": "^6.5.1",
         "@fortawesome/free-regular-svg-icons": "^6.5.1",
@@ -493,6 +494,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cityssm/bulma-sticky-table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cityssm/bulma-sticky-table/-/bulma-sticky-table-2.1.0.tgz",
+      "integrity": "sha512-uTyeudqnbCrbxxu6ikgXGOdrrGaDjwV6WEauwHmk0Ho19b3bnvTgcJgyuPKmOI9WgB88EYHyohiPojwZOECsbw=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.11",
@@ -6776,6 +6782,11 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@cityssm/bulma-sticky-table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cityssm/bulma-sticky-table/-/bulma-sticky-table-2.1.0.tgz",
+      "integrity": "sha512-uTyeudqnbCrbxxu6ikgXGOdrrGaDjwV6WEauwHmk0Ho19b3bnvTgcJgyuPKmOI9WgB88EYHyohiPojwZOECsbw=="
     },
     "@esbuild/aix-ppc64": {
       "version": "0.19.11",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@cityssm/bulma-sticky-table": "^2.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-brands-svg-icons": "^6.5.1",
     "@fortawesome/free-regular-svg-icons": "^6.5.1",

--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -560,7 +560,7 @@ label {
 }
 
 .cve-y-scroll {
-  max-height: 100px;
+  max-height: 15rem;
   overflow-y: auto;
 }
 
@@ -574,6 +574,16 @@ label {
   width: 100%;
 }
 
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 7px;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, .5);
+  box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
 /* Other ends here*/
 
 /* Third party CSS */

--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -1,4 +1,5 @@
 @import "bulma/bulma.sass";
+@import '@cityssm/bulma-sticky-table/sticky-table';
 @import 'bulma/sass/utilities/initial-variables.sass';
 @import './variables.scss';
 @import './bulmaCveCustomizations.scss';

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -148,7 +148,7 @@
             </div>
           </div>
           <div id="cve-cvsss" v-if="cvsss.length > 0" class="mt-5 mb-5">
-            <h4 class="title mb-0">CVSS  <span class="tag has-text-weight-bold ">{{ cvsss.length }} Total</span></h4>
+            <h4 class="title mb-0">CVSS  <span class="tag">{{ cvsss.length }} Total</span></h4>
            
             <div class="cve-learn-more mb-5">
               <router-link to="/CVERecord/UserGuide/#cve-cvss" class="cve-learn-more-link">Learn more</router-link>
@@ -422,7 +422,9 @@ export default {
 };
 </script>
 
-
+<style lang="scss">
+  @import '@/assets/style/globals.scss'; 
+</style>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -148,18 +148,19 @@
             </div>
           </div>
           <div id="cve-cvsss" v-if="cvsss.length > 0" class="mt-5 mb-5">
-            <h4 class="title mb-0">CVSS</h4>
+            <h4 class="title mb-0">CVSS  <span class="tag has-text-weight-bold ">{{ cvsss.length }} Total</span></h4>
+           
             <div class="cve-learn-more mb-5">
               <router-link to="/CVERecord/UserGuide/#cve-cvss" class="cve-learn-more-link">Learn more</router-link>
             </div>
-            <div class="table-container cve-y-scroll" id="downloads-table">
-              <table class="table is-striped is-hoverable cve-border-dark-blue cve-border-bottom-unset mt-0">
+            <div class="table-container cve-cvss-container" id="cvss-table">
+              <table class="table has-sticky-header is-striped is-hoverable cve-border-dark-blue cve-border-bottom-unset mt-0">
                 <thead>
                   <tr>
-                    <th style="width: 20%">Score</th>
-                    <th style="width: 20%">Severity</th>
-                    <th style="width: 20%">Version</th>
-                    <th>Vector String</th>
+                    <th style="width: 20%; top: 0px;">Score</th>
+                    <th style="width: 20%; top: 0px;">Severity</th>
+                    <th style="width: 20%; top: 0px;">Version</th>
+                    <th style="top: 0px;">Vector String</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -421,9 +422,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
-  @import '@/assets/style/globals.scss'; 
-</style>
+
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
@@ -447,5 +446,10 @@ export default {
 
   .cve-title {
     justify-content: left;
+  }
+
+  .cve-cvss-container {
+    max-height: 300px;
+    overflow-y: scroll;
   }
 </style>

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -39,20 +39,20 @@
         </div>
         <div v-if="roleName === 'adp'">
           <div id="cve-ssvcs" v-if="ssvcs.length > 0 && roleName === 'adp'" class="mt-5">
-            <h4 class="title mb-0">SSVC</h4>
+            <h4 class="title mb-0">SSVC  <span class="tag">{{ ssvcs.length }} Total</span></h4>
             <div class="cve-learn-more mb-5">
               <router-link to="/CVERecord/UserGuide/#cve-ssvc" class="cve-learn-more-link">Learn more</router-link>
             </div>
-            <div class="cve-y-scroll">
-              <div class="table-container cve-y-scroll" id="downloads-table">
-                <table class="table is-striped is-hoverable cve-border-dark-blue cve-border-bottom-unset mt-0">
+            <div>
+              <div class="table-container cve-table-scroll-container" id="downloads-table">
+                <table class="table has-sticky-header is-striped is-hoverable cve-border-dark-blue cve-border-bottom-unset mt-0">
                   <thead>
                     <tr>
-                      <th style="width: 20%">Exploitation</th>
-                      <th style="width: 20%">Automatable</th>
-                      <th style="width: 10%">Technical Impact</th>
-                      <th style="width: 10%">Version</th>
-                      <th style="width: 20%">Date Accessed</th>
+                      <th style="width: 20%; top: 0px">Exploitation</th>
+                      <th style="width: 20%; top: 0px">Automatable</th>
+                      <th style="width: 10%; top: 0px">Technical Impact</th>
+                      <th style="width: 10%; top: 0px">Version</th>
+                      <th style="width: 20%; top: 0px">Date Accessed</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -153,7 +153,7 @@
             <div class="cve-learn-more mb-5">
               <router-link to="/CVERecord/UserGuide/#cve-cvss" class="cve-learn-more-link">Learn more</router-link>
             </div>
-            <div class="table-container cve-cvss-container" id="cvss-table">
+            <div class="table-container cve-table-scroll-container" id="cvss-table">
               <table class="table has-sticky-header is-striped is-hoverable cve-border-dark-blue cve-border-bottom-unset mt-0">
                 <thead>
                   <tr>
@@ -450,7 +450,7 @@ export default {
     justify-content: left;
   }
 
-  .cve-cvss-container {
+  .cve-table-scroll-container {
     max-height: 300px;
     overflow-y: scroll;
   }

--- a/src/components/ProductStatus.vue
+++ b/src/components/ProductStatus.vue
@@ -30,8 +30,12 @@
               </div>
             </nav>
             <div id="cve-affected-unaffected-unknown-versions">
-              <p class="cve-product-status-heading" style="border-bottom: 1px solid lightgray;">Versions</p>
-              <div class="column is-12-desktop cve-y-scroll mb-4">
+              <p class="cve-product-status-heading pb-1" style="border-bottom: 1px solid lightgray;">
+                Versions
+                <span class="tag  is-normal">{{ productStatusList.length }} Total</span>
+              </p>
+             
+              <div class="column is-12-desktop cve-versions-scroll mb-4" ref="version-ref">
                 <div id="cve-version-default-status">
                   <p v-if="product.defaultStatus" class="cve-help-text is-italic">
                     <span class="has-text-weight-bold">Default Status: </span>{{product.defaultStatus}}
@@ -126,7 +130,7 @@ export default {
           useCveRecordLookupStore().emptyProductStatus[this.role] = false;
         }
       }
-    },
+    }
   },
   mounted() {
     this.isVendorProductVersionDefaultStatusNa();
@@ -162,6 +166,12 @@ export default {
 }
 .level-item {
   justify-content: left!important;
+}
+
+.cve-versions-scroll {
+  max-height: 235px;
+  border-bottom: 1px solid lightgray;
+  overflow-y: scroll;
 }
  </style>
   

--- a/src/components/ProductStatus.vue
+++ b/src/components/ProductStatus.vue
@@ -32,10 +32,9 @@
             <div id="cve-affected-unaffected-unknown-versions">
               <p class="cve-product-status-heading pb-1" style="border-bottom: 1px solid lightgray;">
                 Versions
-                <span class="tag  is-normal">{{ productStatusList.length }} Total</span>
               </p>
              
-              <div class="column is-12-desktop cve-versions-scroll mb-4" ref="version-ref">
+              <div class="column is-12-desktop cve-versions-scroll mb-4">
                 <div id="cve-version-default-status">
                   <p v-if="product.defaultStatus" class="cve-help-text is-italic">
                     <span class="has-text-weight-bold">Default Status: </span>{{product.defaultStatus}}
@@ -104,6 +103,7 @@ export default {
   data() {
     return {
       useCveRecordLookupStore: useCveRecordLookupStore()
+      
     }
   },
   methods: {
@@ -134,6 +134,7 @@ export default {
   },
   mounted() {
     this.isVendorProductVersionDefaultStatusNa();
+    console.log(this.productStatusList)
   }
 };
 </script>
@@ -169,7 +170,7 @@ export default {
 }
 
 .cve-versions-scroll {
-  max-height: 235px;
+  max-height: 15rem;
   border-bottom: 1px solid lightgray;
   overflow-y: scroll;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
-import "../node_modules/bulma/bulma.sass";
-import "../node_modules/bulma/sass/utilities/initial-variables.sass";
-import "../src/assets/style/globals.scss";
+
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import VueGtag from 'vue-gtag';
@@ -20,7 +18,7 @@ import {
 import {
   faAngleLeft, faAngleRight, faArrowRight, faBlog, faBook, faCaretDown, faCaretUp, faInfoCircle, faCheckCircle, faExclamationCircle, faFileCode,
   faTriangleExclamation, faUpRightFromSquare, faLink, faMinus, faPassport, faPlus, faPodcast, faIdCard, faSearch, faHandshake, faUsersCog,
-  faLaptopCode, faPoll, faTimes, faToolbox, faSitemap, faUser, faUserShield, faBullhorn, faWindowMaximize,
+  faLaptopCode, faPoll, faTimes, faToolbox, faSitemap, faUser, faUserShield, faBullhorn, faWindowMaximize,faArrowDown, faArrowUp
 } from '@fortawesome/free-solid-svg-icons';
 import { faArrowAltCircleRight, faClipboard, faNewspaper } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -28,7 +26,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 library.add(faAngleLeft, faAngleRight, faArrowRight, faBlog, faBook, faCaretDown, faCaretUp, faInfoCircle, faCheckCircle, faExclamationCircle, faFileCode,
   faTriangleExclamation, faUpRightFromSquare, faLink, faMinus, faPassport, faPlus, faPodcast, faIdCard, faSearch, faHandshake, faUsersCog, faLaptopCode,
   faTimes, faToolbox, faSitemap, faUser, faUserShield, faXTwitter, faGithub, faLinkedin, faYoutube, faMedium, faLeanpub, faArrowAltCircleRight,
-  faClipboard, faNewspaper, faBullhorn, faWindowMaximize, faReadme, faPoll, faMastodon);
+  faClipboard, faNewspaper, faBullhorn, faWindowMaximize, faReadme, faPoll, faMastodon, faArrowDown, faArrowUp);
 
 
 const app = createApp(App);


### PR DESCRIPTION
## Summary 
Added new node module to enable Bulma tables to have sticky headers. Also, added styling to ensure scrollbars always show when content is scrollable.

![Screenshot 2024-08-30 at 10 44 31 AM](https://github.com/user-attachments/assets/9bc802fd-c6cd-4889-ad23-9c306c8e1db5)


**Important Changes**

`globals.scss`
- Added styling for scrollbars

`AdpVulnerabilityEnrichment.vue`
- Added classes from `bulma-sticky-table` module to enable sticky headers on tables
- Added table row counts to `CVSS` and `SSVC` tables