### PR TITLE
Resolves #3018 Show cnaContainer date updated instead of full CVE record date updated

### DIFF
--- a/src/views/CVERecord/PublishedRecord.vue
+++ b/src/views/CVERecord/PublishedRecord.vue
@@ -269,8 +269,10 @@ export default {
         this.cveFieldList.datePublishedCveMetadata = this.getDate(value);
       }
     },
+    // Returns CNA Container dateUpdated, not full record dateUpdated
     getRecordUpdatedDate() {
-      const value = this.originalRecordData.cveMetadata?.dateUpdated;
+      const value = this.originalRecordData.containers.cna.providerMetadata?.dateUpdated;
+      
       if (this.hasData(value)) {
         this.cveFieldList.dateUpdatedCveMetadata = this.getDate(value);
       }


### PR DESCRIPTION
## Summary
Changed the updated date in the CNA container on the CVE record page to use the cnaContainer's date updated.

