### PR TITLE
Resolves #3000 Accordion container headers can be clicked anywhere to toggle

### DIFF
--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -452,15 +452,6 @@ div#contentIdForA11y1.collapse-content {
 /* Buefy customizations end here */
 
 /* Bulma-Extensions - Timeline customizations start here (https://wikiki.github.io/components/timeline/) */
-.content h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: black !important;
-}
-
 .timeline .timeline-item .timeline-marker {
   background-color: white !important;
   border: 2px solid $theme-color-primary-darker !important;

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -1,7 +1,7 @@
 <template>
   <div :id="`${sectionAnchorId}`">
     <div class="mb-2">
-      <div @click="togglePanel" class="message-header cve-accordion-header">
+      <button @click="togglePanel" class="message-header cve-accordion-header">
         <slot></slot>
         <button class="button message-header-button"
           :style="{'background-color': '#162e51 !important', 'color': 'white !important'}"
@@ -17,7 +17,7 @@
             />
           </span>
         </button>
-      </div>
+      </button>
       <!-- Panel content is conditionally determined by role -->
       <div :id="`${organizationId}-panel`" v-if="useCveRecordLookupStore.accordionState[organizationId]"
         class="pl-3 pr-3 pt-2 pb-5 cve-container-accordion-panel"
@@ -432,6 +432,7 @@ export default {
   .cve-accordion-header {
     background-color: $theme-color-primary-darker !important;
     cursor: pointer;
+    width: 100%;
   }
   
   .cve-container-accordion-panel {

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -5,7 +5,6 @@
         <slot></slot>
         <button class="button message-header-button"
           :style="{'background-color': '#162e51 !important', 'color': 'white !important'}"
-          @click="togglePanel"
           :aria-expanded="useCveRecordLookupStore.accordionState[organizationId] ? 'true' : 'false'"
           :aria-controls="`${organizationId}-panel`"
         >
@@ -432,6 +431,7 @@ export default {
 
   .cve-accordion-header {
     background-color: $theme-color-primary-darker !important;
+    cursor: pointer;
   }
   
   .cve-container-accordion-panel {

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -1,26 +1,26 @@
 <template>
   <div :id="`${sectionAnchorId}`">
     <div class="mb-2">
-      <div class="message-header cve-accordion-header">
+      <div @click="togglePanel" class="message-header cve-accordion-header">
         <slot></slot>
         <button class="button message-header-button"
           :style="{'background-color': '#162e51 !important', 'color': 'white !important'}"
           @click="togglePanel"
-          :aria-expanded="useCveRecordLookupStore.accordianState[organizationId] ? 'true' : 'false'"
+          :aria-expanded="useCveRecordLookupStore.accordionState[organizationId] ? 'true' : 'false'"
           :aria-controls="`${organizationId}-panel`"
         >
           <span class="icon is-small">
             <p :id="`expandCollapseAltText-${organizationId}`" class="is-hidden">
-              {{useCveRecordLookupStore.accordianState[organizationId] ? 'expand' : 'collapse'}}
+              {{useCveRecordLookupStore.accordionState[organizationId] ? 'expand' : 'collapse'}}
             </p>
-            <font-awesome-icon :icon="useCveRecordLookupStore.accordianState[organizationId] ? 'minus' : 'plus'"
+            <font-awesome-icon :icon="useCveRecordLookupStore.accordionState[organizationId] ? 'minus' : 'plus'"
               aria-hidden="false" focusable="true" :aria-labelledby="`expandCollapseAltText-${organizationId}`"
             />
           </span>
         </button>
       </div>
       <!-- Panel content is conditionally determined by role -->
-      <div :id="`${organizationId}-panel`" v-if="useCveRecordLookupStore.accordianState[organizationId]"
+      <div :id="`${organizationId}-panel`" v-if="useCveRecordLookupStore.accordionState[organizationId]"
         class="pl-3 pr-3 pt-2 pb-5 cve-container-accordion-panel"
       >
         <div>
@@ -258,7 +258,7 @@ export default {
   },
   methods: {
     togglePanel(){
-      useCveRecordLookupStore().accordianState[this.organizationId] = !useCveRecordLookupStore().accordianState[this.organizationId];
+      useCveRecordLookupStore().accordionState[this.organizationId] = !useCveRecordLookupStore().accordionState[this.organizationId];
     },
     hasEnrichmentData(){
       if (this.cwes.length > 0 || this.cvsss.length > 0 || this.kevs.length > 0 || this.ssvcs.length > 0) {

--- a/src/components/NotificationBannerModule.vue
+++ b/src/components/NotificationBannerModule.vue
@@ -66,7 +66,7 @@
             <div>
               <p id="expandCollapseButton" class="is-hidden">Expand or collapse notification button</p>
               <button id="alertIcon" class="button is-text pl-3 pb-0 pt-0" style="height: 1.5rem" aria-labelledby="expandCollapseButton"
-                @click="toggleAccordianItem()" :aria-expanded="isCollapsed ? false : true">
+                @click="toggleAccordionItem()" :aria-expanded="isCollapsed ? false : true">
                 <span class="icon is-small" style="padding-top: 6px;">
                   <p :id="isCollapsed ? 'caret-up' : 'caret-down'" class="is-hidden">close notification button</p>
                   <font-awesome-icon style="font-size: 25px" :icon="isCollapsed ? 'caret-up' : 'caret-down'"
@@ -95,7 +95,7 @@ export default {
     this.setIsCollapsedState();
   },
   methods: {
-    toggleAccordianItem() {
+    toggleAccordionItem() {
       this.isCollapsed = !this.isCollapsed;
       useGlobalNotificationStore().setLocalNotificationStates();
     },

--- a/src/components/TableOfContentsSidebar.vue
+++ b/src/components/TableOfContentsSidebar.vue
@@ -114,31 +114,31 @@ export default {
     return {
       isActive: true,
       isOpen: -1,
-      accordian: {},
-      accordianList: [],
+      accordion: {},
+      accordionList: [],
       selectedSubmenu: [],
     };
   },
   created() {
-    this.setAccordian(false, '', 'subSectionId', 'subSections', ['pageSections', 'appendices']);
+    this.setAccordion(false, '', 'subSectionId', 'subSections', ['pageSections', 'appendices']);
   },
   methods: {
     isExactPath(onPageLink) {
       return useLinkStore().isExactPath(`${this.$route.path}${onPageLink}`, this.$route.fullPath);
     },
-    setAccordian(isHidden, parentId, childId, subSectionPropertyName, topLevelProperties) {
+    setAccordion(isHidden, parentId, childId, subSectionPropertyName, topLevelProperties) {
       Object.keys(this.nav).forEach((topLevelSection) => {
         if (topLevelProperties.includes(topLevelSection)) {
           this.nav[topLevelSection].forEach((item) => {
             item[subSectionPropertyName].forEach((subSection) => {
-              this.accordian[(parentId === '') ? subSection[childId] : `${item[parentId]}${subSection[childId]}`] = isHidden;
+              this.accordion[(parentId === '') ? subSection[childId] : `${item[parentId]}${subSection[childId]}`] = isHidden;
             });
           });
         }
       });
     },
-    toggleAccordianItem(id) {
-      this.accordian[id] = !this.accordian[id];
+    toggleAccordionItem(id) {
+      this.accordion[id] = !this.accordion[id];
     },
     toggleSubmenuItem(id) {
       if (this.selectedSubmenu.includes(id)) {

--- a/src/stores/cveRecordLookup.ts
+++ b/src/stores/cveRecordLookup.ts
@@ -19,7 +19,7 @@ export const useCveRecordLookupStore = defineStore('cveRecordLookup', {
       showJsonRecord: false,
       hasAdpInfo: false,
       emptyProductStatus: {},
-      accordianState: {
+      accordionState: {
         collapseAll: true,
       },
       onPageMenuItems: {

--- a/src/views/About/Process.vue
+++ b/src/views/About/Process.vue
@@ -48,23 +48,23 @@
                 <div class="timeline-content">
                   <h3 class="title">Request</h3>
                   <p>CVE Program participant requests a CVE Identifier (CVE ID).</p>
-                  <section class="cve-accordian">
+                  <section class="cve-accordion">
                     <div class="message">
                       <div class="message-header">
                         <h4 class="title">CVE ID</h4>
-                        <button class="button" @click="toggleAccordianItem('cve-id')"
-                          :aria-expanded="!accordian['cve-id'] ? 'true' : 'false'"
+                        <button class="button" @click="toggleAccordionItem('cve-id')"
+                          :aria-expanded="!accordion['cve-id'] ? 'true' : 'false'"
                           aria-controls="cve-id">
                           <span class="icon is-small">
                             <p id="cve-id-alttext" class="is-hidden">
-                              {{accordian['cve-id'] ? 'collapse' : 'expand'}}
+                              {{accordion['cve-id'] ? 'collapse' : 'expand'}}
                             </p>
-                            <font-awesome-icon :icon="accordian['cve-id'] ? 'plus' : 'minus'"
+                            <font-awesome-icon :icon="accordion['cve-id'] ? 'plus' : 'minus'"
                             aria-hidden="false" focusable="true" aria-labelledby="cve-id-alttext"/>
                           </span>
                         </button>
                       </div>
-                      <div class="message-body" :class="{'is-hidden': accordian['cve-id']}" id="cve-id">
+                      <div class="message-body" :class="{'is-hidden': accordion['cve-id']}" id="cve-id">
                         <div class="block">
                           <p>
                             A CVE ID is a unique, alphanumeric identifier assigned by the CVE Program. Each identifier references a specific
@@ -124,23 +124,23 @@
                     CNA.
                   </p>
                   <p>The CVE Record is now available for download and viewing by the public.</p>
-                  <section class="cve-accordian">
+                  <section class="cve-accordion">
                     <div class="message">
                       <div class="message-header">
                         <h4 class="title">CVE Records</h4>
-                        <button class="button" @click="toggleAccordianItem('cve-record')"
-                          :aria-expanded="!accordian['cve-record'] ? 'true' : 'false'"
+                        <button class="button" @click="toggleAccordionItem('cve-record')"
+                          :aria-expanded="!accordion['cve-record'] ? 'true' : 'false'"
                           aria-controls="cve-record">
                           <span class="icon is-small">
                             <p id="cve-record-alttext" class="is-hidden">
-                              {{accordian['cve-record'] ? 'collapse' : 'expand'}}
+                              {{accordion['cve-record'] ? 'collapse' : 'expand'}}
                             </p>
-                            <font-awesome-icon :icon="accordian['cve-record'] ? 'plus' : 'minus'"
+                            <font-awesome-icon :icon="accordion['cve-record'] ? 'plus' : 'minus'"
                               aria-hidden="false" focusable="true" aria-labelledby="cve-record-alttext"/>
                           </span>
                         </button>
                       </div>
-                      <div class="message-body" :class="{'is-hidden': accordian['cve-record']}" id="cve-record">
+                      <div class="message-body" :class="{'is-hidden': accordion['cve-record']}" id="cve-record">
                         <div class="block">
                           <p>
                             A CVE Record is the descriptive data about a vulnerability associated with a CVE ID, provided by a CVE Numbering
@@ -222,12 +222,12 @@ export default {
   },
   data() {
     return {
-      accordian: { 'cve-id': true, 'cve-record': true },
+      accordion: { 'cve-id': true, 'cve-record': true },
     };
   },
   methods: {
-    toggleAccordianItem(id) {
-      this.accordian[id] = !this.accordian[id];
+    toggleAccordionItem(id) {
+      this.accordion[id] = !this.accordion[id];
     },
   },
 };

--- a/src/views/CVERecord/PublishedRecord.vue
+++ b/src/views/CVERecord/PublishedRecord.vue
@@ -47,10 +47,10 @@
             </div>
             <div class="level-right ml-1">
               <div class="level-item">
-                <div id="cve-accordian-expand-collapse-all-btn" class="buttons mb-0" style="justify-content: flex-end;">
-                  <button id="expand-collpse-all-btn" @click="toggleAccordian" class="button is-small cve-button"
+                <div id="cve-accordion-expand-collapse-all-btn" class="buttons mb-0" style="justify-content: flex-end;">
+                  <button id="expand-collpse-all-btn" @click="toggleAccordion" class="button is-small cve-button"
                   >
-                    {{ useCveRecordLookupStore.accordianState.collapseAll ? 'Collapse' : 'Expand' }} all
+                    {{ useCveRecordLookupStore.accordionState.collapseAll ? 'Collapse' : 'Expand' }} all
                   </button>
                 </div>
               </div>
@@ -148,10 +148,10 @@ export default {
     };
   },
   methods: {
-    toggleAccordian() {
-      const newPanelState = !useCveRecordLookupStore().accordianState.collapseAll;
-      Object.keys(useCveRecordLookupStore().accordianState).forEach( (panelName) => {
-        useCveRecordLookupStore().accordianState[panelName] = newPanelState;
+    toggleAccordion() {
+      const newPanelState = !useCveRecordLookupStore().accordionState.collapseAll;
+      Object.keys(useCveRecordLookupStore().accordionState).forEach( (panelName) => {
+        useCveRecordLookupStore().accordionState[panelName] = newPanelState;
       });
     },
     populateOnPageMenu() {
@@ -208,20 +208,20 @@ export default {
     setupContainersAccordionStateOnPageMenu() {
       this.cnaContainer = this.originalRecordData.containers.cna;
       if (this.cnaContainer?.providerMetadata?.orgId) {
-        useCveRecordLookupStore().accordianState[`cna-${this.cnaContainer.providerMetadata.orgId}`] = true;
+        useCveRecordLookupStore().accordionState[`cna-${this.cnaContainer.providerMetadata.orgId}`] = true;
       }
 
       if (this.originalRecordData?.containers?.adp) {
         this.originalRecordData.containers.adp.forEach((adp) => {
           if (adp.providerMetadata.shortName.toLowerCase() === useCveRecordLookupStore().cveProgramShortName) {
             this.cveProgramContainer = adp;
-            useCveRecordLookupStore().accordianState[`cve-program-${adp.providerMetadata.orgId}`] = true;
+            useCveRecordLookupStore().accordionState[`cve-program-${adp.providerMetadata.orgId}`] = true;
           }
         });
       }
       
       Object.keys(this.adpContainers).forEach( (adpName) => {
-        useCveRecordLookupStore().accordianState[`adp-${this.adpContainers[adpName].providerMetadata.orgId}`] = false;
+        useCveRecordLookupStore().accordionState[`adp-${this.adpContainers[adpName].providerMetadata.orgId}`] = false;
       });
 
       this.populateOnPageMenu();

--- a/src/views/CVERecord/PublishedRecord.vue
+++ b/src/views/CVERecord/PublishedRecord.vue
@@ -62,14 +62,14 @@
               <AdpVulnerabilityEnrichment v-if="Object.keys(cnaContainer).length > 0" role="cna" :selectedCnaData="cveFieldList"
                 :containerObject="cnaContainer" :orgId="`cna-${cnaContainer.providerMetadata.orgId}`" :anchorId="cnaContainer.onPageMenu.anchorId"
               >
-                <h3 class="mb-1 has-text-white cve-capitalize-first-letter">{{ cnaContainer.onPageMenu.label }}</h3>
+                <h1 class="mb-1 has-text-white cve-capitalize-first-letter">{{ cnaContainer.onPageMenu.label }}</h1>
               </AdpVulnerabilityEnrichment>
               <!-- <AdpVulnerabilityEnrichment v-if="!useCveRecordLookupStore.hasHistoricalReferences" role="cna" :containerObject="cnaContainer"></AdpVulnerabilityEnrichment> -->
               <AdpVulnerabilityEnrichment v-if="Object.keys(cveProgramContainer).length > 0" role='cveProgram' 
                 :selectedCnaData="{}" :containerObject="cveProgramContainer" :orgId="`cve-program-${cveProgramContainer.providerMetadata.orgId}`"
                 :anchorId="cveProgramContainer.onPageMenu.anchorId"
               >
-                <h3 class="mb-1 has-text-white cve-capitalize-first-letter">{{ cveProgramContainer.onPageMenu.label }}</h3>
+                <h1 class="mb-1 has-text-white cve-capitalize-first-letter">{{ cveProgramContainer.onPageMenu.label }}</h1>
               </AdpVulnerabilityEnrichment>
             </div>
             <div v-if="Object.keys(adpContainers).length > 0" id="cve-adp-containers" class="mt-6">
@@ -81,7 +81,7 @@
                 <AdpVulnerabilityEnrichment v-if="adpContainer.providerMetadata.shortName === 'CISA-ADP'" role="adp" :selectedCnaData="{}" 
                   :containerObject="adpContainer" :orgId="`adp-${adpContainer.providerMetadata.orgId}`" :anchorId="adpContainer.onPageMenu.anchorId"
                 >
-                  <h3 class="mb-1 has-text-white cve-capitalize-first-letter">{{ adpContainer.onPageMenu.label }}</h3>
+                  <h1 class="mb-1 has-text-white cve-capitalize-first-letter">{{ adpContainer.onPageMenu.label }}</h1>
                 </AdpVulnerabilityEnrichment>
                 <!-- <div v-for="(adpContainer) in cveFieldList.productsStatus.adp" :key="adpContainer.key"
                   class="mt-5"

--- a/src/views/CVERecord/RejectedRecordOrId.vue
+++ b/src/views/CVERecord/RejectedRecordOrId.vue
@@ -25,7 +25,7 @@
           </nav>
           <div role="information" class="notification is-info is-light p-3 mt-4">
             <div class="is-flex" style="justify-content: center;">
-                <section class="cve-accordian" style="flex: 0 0 100%;">
+                <section class="cve-accordion" style="flex: 0 0 100%;">
                     <div class="message" style="background: transparent !important;">
                       <div class="message-header p-0"
                         style="background: transparent !important;border-bottom: unset !important">

--- a/src/views/CVERecord/ReservedId.vue
+++ b/src/views/CVERecord/ReservedId.vue
@@ -22,7 +22,7 @@
           </nav>
           <div role="information" class="notification is-info is-light p-3">
             <div class="is-flex" style="justify-content: center;">
-                <section class="cve-accordian" style="flex: 0 0 100%;">
+                <section class="cve-accordion" style="flex: 0 0 100%;">
                     <div class="message" style="background: transparent !important;">
                       <div class="message-header p-0"
                         style="background: transparent !important;border-bottom: unset !important">

--- a/src/views/Media/News/BlogArchives.vue
+++ b/src/views/Media/News/BlogArchives.vue
@@ -12,30 +12,30 @@
               to the <router-link to="/Media/News/Blogs">Blogs</router-link> page.
             </p>
             <div class="has-text-right pb-4">
-              <button class="button cve-button" @click="toggleAccordianAll()">
-                {{accordian.length > 1 ? 'Collapse All' : 'Expand All'}}
+              <button class="button cve-button" @click="toggleAccordionAll()">
+                {{accordion.length > 1 ? 'Collapse All' : 'Expand All'}}
               </button>
             </div>
-            <section class="cve-accordian">
+            <section class="cve-accordion">
               <div v-for="(archiveYear, index) in Object.keys(sortedEntries).sort(function(a,b){return b-a})"
                 :key="index" class="message">
                 <div class="message-header cve-base-light-gray-borders-bg">
                   <p class="message-label has-text-weight-bold" style="margin-top: auto; margin-bottom: auto;">
                     {{archiveYear}}
                   </p>
-                  <button class="button" @click="toggleAccordianItem(archiveYear)"
-                    :aria-expanded="!accordian.includes(archiveYear) ? 'true' : 'false'"
+                  <button class="button" @click="toggleAccordionItem(archiveYear)"
+                    :aria-expanded="!accordion.includes(archiveYear) ? 'true' : 'false'"
                     :aria-controls="archiveYear">
                     <span class="icon is-small">
                       <p :id="archiveYear + '-alttext'" class="is-hidden">
-                        {{accordian.includes(archiveYear) ? 'collapse' : 'expand'}}
+                        {{accordion.includes(archiveYear) ? 'collapse' : 'expand'}}
                       </p>
-                      <font-awesome-icon :icon="accordian.includes(archiveYear) ? 'plus' : 'minus'"
+                      <font-awesome-icon :icon="accordion.includes(archiveYear) ? 'plus' : 'minus'"
                         aria-hidden="false" focusable="true" :aria-labelledby="archiveYear + '-alttext'"/>
                     </span>
                   </button>
                 </div>
-                <div class="message-body" v-show="accordian.includes(archiveYear)" :id="archiveYear">
+                <div class="message-body" v-show="accordion.includes(archiveYear)" :id="archiveYear">
                   <div class="table-container" :id="archiveYear">
                     <table class="table is-striped is-hoverable cve-border-dark-blue cve-border-bottom-unset">
                       <thead>
@@ -85,7 +85,7 @@ export default {
   data() {
     return {
       archiveBlogs: newsData.archiveBlogs,
-      accordian: [],
+      accordion: [],
       sortedEntries: {},
       isNavSidebarHiddenTouch: false,
     };
@@ -121,7 +121,7 @@ export default {
       });
       Object.keys(blogArchivesByYear).forEach((archiveYear) => {
         sortedBlogArchives[archiveYear] = this.sortYearEntries(blogArchivesByYear[archiveYear]);
-        this.accordian.push(archiveYear);
+        this.accordion.push(archiveYear);
       });
       this.sortedEntries = sortedBlogArchives;
     },
@@ -133,21 +133,21 @@ export default {
       });
       return sortedEntries;
     },
-    toggleAccordianAll() {
-      if (this.accordian.length > 1) {
-        this.accordian = [];
+    toggleAccordionAll() {
+      if (this.accordion.length > 1) {
+        this.accordion = [];
       } else {
         Object.keys(this.sortedEntries).forEach((year) => {
-          this.accordian.push(year);
+          this.accordion.push(year);
         });
       }
     },
-    toggleAccordianItem(id) {
-      if (this.accordian.includes(id)) {
-        const index = this.accordian.indexOf(id);
-        this.accordian.splice(index, 1);
+    toggleAccordionItem(id) {
+      if (this.accordion.includes(id)) {
+        const index = this.accordion.indexOf(id);
+        this.accordion.splice(index, 1);
       } else {
-        this.accordian.push(id);
+        this.accordion.push(id);
       }
     },
   },

--- a/src/views/PartnerInformation/ListofPartners.vue
+++ b/src/views/PartnerInformation/ListofPartners.vue
@@ -10,25 +10,25 @@
               Contact and other information for Top-Level Roots, Roots, CNAs, and CNA-LRs are below. Select the partner’s name to view its
               information.
             </p>
-            <section class="cve-accordian">
+            <section class="cve-accordion">
               <div class="message">
                 <div class="message-header cve-base-light-gray-borders-bg">
                   <p class="message-label has-text-weight-bold" style="margin-top: auto; margin-bottom: auto;">
                     Request a CVE ID / Update a CVE Record
                   </p>
-                  <button class="button" @click="toggleAccordianItem('report')"
-                    :aria-expanded="!accordian['report'] ? 'true' : 'false'"
+                  <button class="button" @click="toggleAccordionItem('report')"
+                    :aria-expanded="!accordion['report'] ? 'true' : 'false'"
                     aria-controls="report">
                     <span class="icon is-small">
                       <p id="record-alttext" class="is-hidden">
-                        {{accordian['report'] ? 'collapse' : 'expand'}}
+                        {{accordion['report'] ? 'collapse' : 'expand'}}
                       </p>
-                      <font-awesome-icon :icon="accordian['report'] ? 'plus' : 'minus'"
+                      <font-awesome-icon :icon="accordion['report'] ? 'plus' : 'minus'"
                         aria-hidden="false" focusable="true" aria-labelledby="record-alttext"/>
                     </span>
                   </button>
                 </div>
-                <div class="message-body" :class="{'is-hidden': accordian['report']}" id="report">
+                <div class="message-body" :class="{'is-hidden': accordion['report']}" id="report">
                   <div class="block" id="report">
                     <ol class="ml-4">
                       <li class="pb-1">To request a CVE ID from a CNA or CNA-LR, follow the
@@ -50,19 +50,19 @@
               <div class="message">
                 <div class="message-header cve-base-light-gray-borders-bg">
                   <p class="message-label has-text-weight-bold" style="margin-top: auto; margin-bottom: auto;">Program Roles / Organization Types</p>
-                  <button class="button" @click="toggleAccordianItem('programRoles')"
-                    :aria-expanded="!accordian['programRoles'] ? 'true' : 'false'"
+                  <button class="button" @click="toggleAccordionItem('programRoles')"
+                    :aria-expanded="!accordion['programRoles'] ? 'true' : 'false'"
                     aria-controls="programRoles">
                     <span class="icon is-small">
                       <p id="programRolesalttext" class="is-hidden">
-                        {{accordian['programRoles'] ? 'collapse' : 'expand'}}
+                        {{accordion['programRoles'] ? 'collapse' : 'expand'}}
                       </p>
-                      <font-awesome-icon :icon="accordian['programRoles'] ? 'plus' : 'minus'"
+                      <font-awesome-icon :icon="accordion['programRoles'] ? 'plus' : 'minus'"
                         aria-hidden="false" focusable="true" aria-labelledby="programRolesalttext"/>
                     </span>
                   </button>
                 </div>
-                <div class="message-body" :class="{'is-hidden': accordian['programRoles']}" id="programRoles">
+                <div class="message-body" :class="{'is-hidden': accordion['programRoles']}" id="programRoles">
                   <div class="block">
                     <p class="subtitle">Program Roles</p>
                     <ul>
@@ -102,15 +102,15 @@
               </button>
             </div>
           </div> <!-- end search field groups -->
-          <div class="cve-accordian mt-1">
-            <button href="/SiteSearch" @click="toggleAccordianItem('searchTips')" class="button cve-button-outline cve-base-light-gray-borders-bg">
+          <div class="cve-accordion mt-1">
+            <button href="/SiteSearch" @click="toggleAccordionItem('searchTips')" class="button cve-button-outline cve-base-light-gray-borders-bg">
               <span class="is-size-7 has-text-weight-bold">Search Tips</span>
               <span class="icon cve-icon-xxs">
-                <font-awesome-icon :icon="accordian['searchTips'] ? 'plus' : 'minus'"
+                <font-awesome-icon :icon="accordion['searchTips'] ? 'plus' : 'minus'"
                   aria-hidden="false" focusable="true" aria-labelledby="record-alttext"/>
               </span>
             </button>
-            <div class="message pt-1 pr-3 pb-1 pl-3" :class="{'is-hidden': accordian['searchTips']}" id="report">
+            <div class="message pt-1 pr-3 pb-1 pl-3" :class="{'is-hidden': accordion['searchTips']}" id="report">
               <p>
                 Search for a CNA partner by <b>name</b>, <b>scope</b> keyword(s), <b>program role</b>, or <b>organization type</b>.<br/>
                 For example: “Top-Level Root”, “Root”, or “CNA-LR”, finds partners by their Program Role.
@@ -285,7 +285,7 @@ export default {
       isPartnerRoleVisible: false,
       isParterOrgType: false,
       isFocus: false,
-      accordian: { report: true, programRoles: true, searchTips: true },
+      accordion: { report: true, programRoles: true, searchTips: true },
     };
   },
   created() {
@@ -446,8 +446,8 @@ export default {
         return null;
       });
     },
-    toggleAccordianItem(id) {
-      this.accordian[id] = !this.accordian[id];
+    toggleAccordionItem(id) {
+      this.accordion[id] = !this.accordion[id];
     },
   },
 };

--- a/src/views/PartnerInformation/Partner.vue
+++ b/src/views/PartnerInformation/Partner.vue
@@ -179,23 +179,23 @@
                 <div class="timeline-content">
                   <h3 class="title">Meet Requirements</h3>
                   <p>Prospective partner meets requirements.</p>
-                  <section class="cve-accordian">
+                  <section class="cve-accordion">
                     <div class="message">
                       <div class="message-header">
                         <h4 class="title">Requirements</h4>
-                        <button class="button cve-process-list-btn" @click="toggleAccordianItem('requirements')"
-                          :aria-expanded="!accordian['requirements'] ? 'true' : 'false'"
+                        <button class="button cve-process-list-btn" @click="toggleAccordionItem('requirements')"
+                          :aria-expanded="!accordion['requirements'] ? 'true' : 'false'"
                           aria-controls="requirements">
                           <span class="icon is-small">
                             <p id="requirements-alttext" class="is-hidden">
-                              {{accordian['requirements'] ? 'collapse' : 'expand'}}
+                              {{accordion['requirements'] ? 'collapse' : 'expand'}}
                             </p>
-                            <font-awesome-icon :icon="accordian['requirements'] ? 'plus' : 'minus'"
+                            <font-awesome-icon :icon="accordion['requirements'] ? 'plus' : 'minus'"
                             aria-hidden="false" focusable="true" aria-labelledby="requirements-alttext"/>
                           </span>
                         </button>
                       </div>
-                      <div class="message-body" :class="{'is-hidden': accordian['requirements']}" id="requirements">
+                      <div class="message-body" :class="{'is-hidden': accordion['requirements']}" id="requirements">
                         <div class="block">
                           <p>
                             <ul>
@@ -233,23 +233,23 @@
                 <div class="timeline-content">
                   <h3 class="title">Onboard</h3>
                   <p>Organization is onboarded.</p>
-                  <section class="cve-accordian">
+                  <section class="cve-accordion">
                     <div class="message">
                       <div class="message-header">
                         <h4 class="title">Onboarding</h4>
-                        <button class="button cve-process-list-btn" @click="toggleAccordianItem('onboarding')"
-                          :aria-expanded="!accordian['onboarding'] ? 'true' : 'false'"
+                        <button class="button cve-process-list-btn" @click="toggleAccordionItem('onboarding')"
+                          :aria-expanded="!accordion['onboarding'] ? 'true' : 'false'"
                           aria-controls="onboarding">
                           <span class="icon is-small">
                             <p id="onboarding-alttext" class="is-hidden">
-                              {{accordian['onboarding'] ? 'collapse' : 'expand'}}
+                              {{accordion['onboarding'] ? 'collapse' : 'expand'}}
                             </p>
-                            <font-awesome-icon :icon="accordian['onboarding'] ? 'plus' : 'minus'"
+                            <font-awesome-icon :icon="accordion['onboarding'] ? 'plus' : 'minus'"
                             aria-hidden="false" focusable="true" aria-labelledby="onboarding-alttext"/>
                           </span>
                         </button>
                       </div>
-                      <div class="message-body" :class="{'is-hidden': accordian['onboarding']}" id="onboarding">
+                      <div class="message-body" :class="{'is-hidden': accordion['onboarding']}" id="onboarding">
                         <div class="block">
                           <p>
                             <ul>
@@ -318,12 +318,12 @@ export default {
   },
   data() {
     return {
-      accordian: { requirements: true, onboarding: true },
+      accordion: { requirements: true, onboarding: true },
     };
   },
   methods: {
-    toggleAccordianItem(id) {
-      this.accordian[id] = !this.accordian[id];
+    toggleAccordionItem(id) {
+      this.accordion[id] = !this.accordion[id];
     },
   },
 };

--- a/src/views/ProgramOrganization/Board.vue
+++ b/src/views/ProgramOrganization/Board.vue
@@ -69,17 +69,17 @@
               Members
             </h2>
 
-            <section class="cve-accordian mb-6">
+            <section class="cve-accordion mb-6">
               <div class="message has-text-centered">
                 <div class="message-header cve-base-light-gray-borders-bg">
                   <h3 class="title mb-0">Current Members</h3>
-                  <button class="button" @click="toggleAccordianItem('current-members')" aria-label="expandCollapseCurrentMembers">
+                  <button class="button" @click="toggleAccordionItem('current-members')" aria-label="expandCollapseCurrentMembers">
                     <span class="icon is-small">
-                      <font-awesome-icon :icon="accordian['current-members'] ? 'plus' : 'minus'"/>
+                      <font-awesome-icon :icon="accordion['current-members'] ? 'plus' : 'minus'"/>
                     </span>
                   </button>
                 </div>
-                <div class="message-body" :class="{'is-hidden': accordian['current-members']}">
+                <div class="message-body" :class="{'is-hidden': accordion['current-members']}">
                   <div class="block">
                     <div class="hero-body" v-for="(chuckedBoardMembersList, index) in
                       preprocessedBoardMembersList"
@@ -236,7 +236,7 @@ export default {
   data() {
     return {
       pastMembersTab: 0,
-      accordian: { 'current-members': false },
+      accordion: { 'current-members': false },
     };
   },
   computed: {
@@ -262,8 +262,8 @@ export default {
     },
   },
   methods: {
-    toggleAccordianItem(id) {
-      this.accordian[id] = !this.accordian[id];
+    toggleAccordionItem(id) {
+      this.accordion[id] = !this.accordion[id];
     },
   },
 };

--- a/src/views/ReportRequest/ReportRequestForNonCNAs.vue
+++ b/src/views/ReportRequest/ReportRequestForNonCNAs.vue
@@ -48,7 +48,7 @@
                         <template #empty>No results found</template>
                         </b-autocomplete>
                       </b-field>
-                      <div class="cve-accordian">
+                      <div class="cve-accordion">
                         <button @click="showTip = !showTip" class="button is-ghost pt-0 pb-0 pl-0">
                           Tips for finding correct CNA
                         </button>

--- a/src/views/ResourcesSupport/AllResources/CveServices.vue
+++ b/src/views/ResourcesSupport/AllResources/CveServices.vue
@@ -293,7 +293,7 @@
               <p>CVE Services Clients are used to reserve CVE IDs and populate, submit, and update CVE Records.</p>
               <div role="information" class="notification is-info is-light p-3">
                 <div class="is-flex" style="justify-content: center;">
-                    <section class="cve-accordian" style="flex: 0 0 100%;">
+                    <section class="cve-accordion" style="flex: 0 0 100%;">
                         <div class="message" style="background: transparent !important;">
                           <div class="message-header p-0"
                             style="background: transparent !important;border-bottom: unset !important">

--- a/src/views/ResourcesSupport/FAQs.vue
+++ b/src/views/ResourcesSupport/FAQs.vue
@@ -5,7 +5,7 @@
           <aside class="menu is-hidden-touch cve-sidebar-menu mt-3">
             <p class="menu-label cve-capitalize-first-letter message-label">All Questions</p>
             <ul class="menu-list cve-capitalize-first-letter">
-              <li v-for="(submenuObj, index) in accordianList" :key="submenuObj.sectionId">
+              <li v-for="(submenuObj, index) in accordionList" :key="submenuObj.sectionId">
                 <span class="is-flex" style="justify-content: space-between; width: inherit">
                   <router-link
                     :to="`#${submenuObj.sectionId}`"
@@ -46,28 +46,28 @@
             <h1 class="title">Frequently Asked Questions (FAQs)</h1>
             <ExternalLinkMessage/>
             <div class="buttons mb-0" style="justify-content: flex-end;">
-              <button class="button cve-button" @click="setAccordian('sectionId', 'questionId')">{{isExpandAll ? 'Expand' : 'Collapse'}} all</button>
+              <button class="button cve-button" @click="setAccordion('sectionId', 'questionId')">{{isExpandAll ? 'Expand' : 'Collapse'}} all</button>
             </div>
-            <section class="cve-accordian">
-              <div class="message" v-for="item in accordianList" :key="item.sectionId">
+            <section class="cve-accordion">
+              <div class="message" v-for="item in accordionList" :key="item.sectionId">
                 <h2 :id="item.sectionId" class="title">{{item.sectionTitle}}</h2>
                 <div v-for="qAndA in item.sectionQuestions" :key="item.sectionId + qAndA.questionId">
                   <div class="message-header cve-base-light-gray-borders-bg">
                     <p :id="item.sectionId + qAndA.questionId" class="mt-2 mb-2">{{qAndA.questionText}}?</p>
-                    <button class="button message-header-button" @click="toggleAccordianItem(item.sectionId + qAndA.questionId)"
-                      :aria-expanded="accordian[item.sectionId + qAndA.questionId] ? 'false' : 'true'"
+                    <button class="button message-header-button" @click="toggleAccordionItem(item.sectionId + qAndA.questionId)"
+                      :aria-expanded="accordion[item.sectionId + qAndA.questionId] ? 'false' : 'true'"
                       :aria-controls="item.sectionId + qAndA.questionId + 'response'">
                       <span class="icon is-small">
                         <p :id="'expandCollapseAltText' + item.sectionId + qAndA.questionId" class="is-hidden">
-                          {{accordian[item.sectionId + qAndA.questionId] ? 'collapse' : 'expand'}}
+                          {{accordion[item.sectionId + qAndA.questionId] ? 'collapse' : 'expand'}}
                         </p>
-                        <font-awesome-icon :icon="accordian[item.sectionId + qAndA.questionId] ? 'plus' : 'minus'"
+                        <font-awesome-icon :icon="accordion[item.sectionId + qAndA.questionId] ? 'plus' : 'minus'"
                           aria-hidden="false" focusable="true" :aria-labelledby="'expandCollapseAltText' + item.sectionId + qAndA.questionId"/>
                       </span>
                     </button>
                   </div>
                   <div :id="item.sectionId + qAndA.questionId + 'response'" class="message-body"
-                    :class="{'is-hidden': accordian[item.sectionId + qAndA.questionId]}">
+                    :class="{'is-hidden': accordion[item.sectionId + qAndA.questionId]}">
                     <div v-if="qAndA.questionId == 'search_cve'" class="pb-3">
                       <p>The following methods are available:</p>
                       <strong>CVE ID Lookup</strong>
@@ -98,29 +98,29 @@ export default {
   name: 'FAQs',
   data() {
     return {
-      accordian: {},
-      accordianList: faqsData,
+      accordion: {},
+      accordionList: faqsData,
       selectedSubmenu: [],
       isExpandAll: true,
     };
   },
   created() {
-    this.setAccordian('sectionId', 'questionId');
+    this.setAccordion('sectionId', 'questionId');
   },
   methods: {
     isExactPath(onPageLink) {
       return useLinkStore().isExactPath(`${this.$route.path}${onPageLink}`, this.$route.fullPath);
     },
-    setAccordian(parentId, childId) {
+    setAccordion(parentId, childId) {
       this.isExpandAll = !this.isExpandAll;
-      this.accordianList.forEach((item) => {
+      this.accordionList.forEach((item) => {
         item.sectionQuestions.forEach((qAndA) => {
-          this.accordian[(parentId === '') ? qAndA[childId] : `${item[parentId]}${qAndA[childId]}`] = this.isExpandAll;
+          this.accordion[(parentId === '') ? qAndA[childId] : `${item[parentId]}${qAndA[childId]}`] = this.isExpandAll;
         });
       });
     },
-    toggleAccordianItem(id) {
-      this.accordian[id] = !this.accordian[id];
+    toggleAccordionItem(id) {
+      this.accordion[id] = !this.accordion[id];
     },
     toggleSubmenuItem(id) {
       if (this.selectedSubmenu.includes(id)) {


### PR DESCRIPTION
## Summary
Previously, to collapse or expand a container on the CVE record details page, the +/- button had to be clicked. Now, any where on the container header can be clicked to expand/collapse.

**Important Changes**

`globals.scss`
- Removed h1,2,3,4,5,6 color styling. No longer needed as default font color is black and it overwrote other styling

`AdpvulnerabilityEnrichment.vue`
- Replaced accordion div with button
- Fixed typos
- Removed toggle function from +/- button and added it to the accordion button

Multiple files
- Fixed accordion typo