### PR TITLE
Resolves #3080 Fixed column title color for CNAs added by Year table

### DIFF
--- a/src/views/About/Metrics.vue
+++ b/src/views/About/Metrics.vue
@@ -240,8 +240,10 @@
               <div class="cve-scrollx-table-container">
                 <table class="table is-striped is-hoverable cve-border-dark-blue">
                   <thead>
-                    <th>Year</th>
-                    <th v-for="year in cnasAddedByYear.years" :key="year">{{year}}</th>
+                    <tr>
+                      <th>Year</th>
+                      <th v-for="year in cnasAddedByYear.years" :key="year">{{year}}</th>
+                    </tr>
                   </thead>
                   <tbody>
                     <tr v-for="month in [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October',


### PR DESCRIPTION
## Summary 
The CNAs added by Year table on the Metrics page had column titles displayed in the wrong font color. This was addressed by adding the correct <tr> tags.

![Screenshot 2024-09-27 at 11 55 33 AM](https://github.com/user-attachments/assets/c62e6a1e-282a-455f-a8ae-94d634129bec)


**Important Changes**
`Metrics.vue`
- Added `<tr>` under `<thead>` so the correct styling is applied.
