### PR TITLE
Resolves #2955 Added red badge styling to Active SSVCs

### DIFF
--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -57,7 +57,12 @@
                   </thead>
                   <tbody>
                     <tr v-for="ssvc in ssvcs" :key="ssvc.key">
-                      <td data-label="Exploitation" style="width: 20%">{{ ssvc.exploitation }}</td>
+                      <td data-label="Exploitation" style="width: 20%">
+                        <span :class="{'is-danger tag has-text-weight-bold is-uppercase' : ssvc.exploitation === 'active'}">
+                          {{ ssvc.exploitation }}
+                        </span>
+                        
+                      </td>
                       <td data-label="Automatable" style="width: 10%">{{ ssvc.automatable }}</td>
                       <td data-label="Technical Impact" style="width: 30%">{{ ssvc['technical impact'] }}</td>
                       <td data-label="Version" style="width: 10%">{{ ssvc.version }}</td>

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -58,7 +58,7 @@
                   <tbody>
                     <tr v-for="ssvc in ssvcs" :key="ssvc.key">
                       <td data-label="Exploitation" style="width: 20%">
-                        <span :class="{'is-danger tag has-text-weight-bold is-uppercase' : ssvc.exploitation === 'active'}">
+                        <span :class="{'is-danger tag has-text-weight-bold is-uppercase' : ssvc.exploitation.toLowerCase() === 'active'}">
                           {{ ssvc.exploitation }}
                         </span>
                         

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -61,7 +61,6 @@
                         <span :class="{'is-danger tag has-text-weight-bold is-uppercase' : ssvc.exploitation.toLowerCase() === 'active'}">
                           {{ ssvc.exploitation }}
                         </span>
-                        
                       </td>
                       <td data-label="Automatable" style="width: 10%">{{ ssvc.automatable }}</td>
                       <td data-label="Technical Impact" style="width: 30%">{{ ssvc['technical impact'] }}</td>

--- a/src/views/CVERecord/RejectedRecordOrId.vue
+++ b/src/views/CVERecord/RejectedRecordOrId.vue
@@ -84,7 +84,7 @@
             </span>
           </div>
           <p id="cve-rejected-reason" class="content has-text-justified">
-            <span class="has-text-weight-bold">Rejected Reason:</span>
+            <span class="has-text-weight-bold">Rejected Reason: </span>
             <span>
               <span v-if="cveFieldList.rejectedReasons.length == 0">
                 This CVE ID was unused by the <router-link to="/ProgramOrganization/CNAs">CNA</router-link>.


### PR DESCRIPTION
## Summary
Added red badge styling to Active SSVCs. Other SSVC types remain plain text.

Also resolves #2999 

![Screenshot 2024-09-27 at 3 44 14 PM](https://github.com/user-attachments/assets/21ee49ac-aad6-43fd-9e67-980d03e0fc4a)

**Important Changes**
- Added dynamic classes to add styiling