### PR TITLE
Resolves #3077 Added scrolling to references list on publish records

### DIFF
--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -561,6 +561,14 @@ label {
   overflow-x: auto
 }
 
+.cve-scroll-box {
+  max-height: 15rem;
+  border-bottom: 1px solid lightgray;
+  overflow-y: scroll;
+  border-top: 1px solid lightgray;
+}
+
+
 .cve-w-100 {
   width: 100%;
 }
@@ -575,6 +583,7 @@ label {
   background-color: rgba(0, 0, 0, .5);
   box-shadow: 0 0 1px rgba(255, 255, 255, .5);
 }
+
 /* Other ends here*/
 
 /* Third party CSS */

--- a/src/assets/style/globals.scss
+++ b/src/assets/style/globals.scss
@@ -566,6 +566,7 @@ label {
   border-bottom: 1px solid lightgray;
   overflow-y: scroll;
   border-top: 1px solid lightgray;
+  padding: .75rem
 }
 
 

--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -71,12 +71,12 @@
               </div>
             </div>
           </div>
-          <div id="cve-kevs" v-if="kevs.length > 0 && roleName === 'adp'" class="cve-scroll-border-bottom mt-5">
+          <div id="cve-kevs" v-if="kevs.length > 0 && roleName === 'adp'" class="mt-5">
             <h4 class="title mb-0">KEV <span class="tag">{{ kevs.length }} Total</span></h4>
-            <div class="cve-learn-more cve-scroll-border-bottom">
+            <div class="cve-learn-more ">
               <router-link to="/CVERecord/UserGuide/#cve-kev" class="cve-learn-more-link">Learn more</router-link>
             </div>
-            <div class="cve-y-scroll mt-3 mb-3">
+            <div class="cve-y-scroll cve-scroll-box mt-3">
               <ul class="mt-1">
                 <li v-for="kev in kevs" :key="kev.key">
                   <a :href="kev.reference" target="_blank">{{ kev.reference }}</a><span class="is-italic cve-help-text"> ({{ kev.dateAdded }})</span>
@@ -131,13 +131,13 @@
           </div>
         </div>
         <div v-if="roleName !== 'cveProgram'">
-          <div id="cve-cwes" v-if="cwes.length > 0" class="cve-scroll-border-bottom mt-5">
+          <div id="cve-cwes" v-if="cwes.length > 0" class="mt-5">
             <h4 class="title mb-0">CWE <span class="tag">{{ cwes.length }} Total</span></h4>
-            <div class="cve-learn-more cve-scroll-border-bottom mb-5">
+            <div class="cve-learn-more mb-3">
               <router-link to="/CVERecord/UserGuide/#cve-cwe" class="cve-learn-more-link">Learn more</router-link>
             </div>
-            <div class="cve-y-scroll">
-              <ul class="mt-0 mb-3">
+            <div class="cve-y-scroll cve-scroll-box">
+              <ul class="mt-0 mb-0">
                 <li v-for="cwe in cwes" :key="cwe.key">
                   <a v-if="cwe.cweId !== 'CWE ID not provided'" :href="`https://cwe.mitre.org/data/definitions/${cwe.cweNumber}.html`" target="_blank">
                     <span class="has-text-weight-bold">{{ cwe.cweId }}<span v-if="cwe.description.length > 0">: </span></span>
@@ -460,7 +460,4 @@ export default {
     overflow-y: scroll;
   }
 
-  .cve-scroll-border-bottom {
-    border-bottom: 1px solid lightgray;
-  }
 </style>

--- a/src/components/CveRecordReferences.vue
+++ b/src/components/CveRecordReferences.vue
@@ -3,23 +3,25 @@
     class="mt-5"
     style="word-break:break-all;"
   >
-    <h4 class="title mb-0">References</h4>
-    <ul>
-      <li v-for="(reference, index) in references" :key="`link-${index}`" class="cve-word-wrap">
-        <span class="icon-text">
-          <a :href="reference.url" target="_blank">
-            {{ (typeof reference.name !== 'undefined' && reference.name.length > 0) ? `${reference.hostname}: ${reference.name}` : reference.url }}
-            <span class="icon cve-icon-xxs">
-              <p id="enewsletter" class="is-hidden">external site</p>
-              <font-awesome-icon icon="external-link-alt" aria-labelledby="enewsletter"></font-awesome-icon>
-            </span>
-          </a>
-        </span>
-        <span v-for="tag in reference.tags" :key="tag">
-          <span class="tag ml-2" v-if="tag.length > 0">{{tag}}</span>
-        </span>
-      </li>
-    </ul>
+    <h4 class="title mb-2">References <span class="tag">{{ references.length }} Total</span></h4>
+    <div class="cve-scroll-box p-5">
+      <ul>
+        <li v-for="(reference, index) in references" :key="`link-${index}`" class="cve-word-wrap">
+          <span class="icon-text">
+            <a :href="reference.url" target="_blank">
+              {{ (typeof reference.name !== 'undefined' && reference.name.length > 0) ? `${reference.hostname}: ${reference.name}` : reference.url }}
+              <span class="icon cve-icon-xxs">
+                <p id="enewsletter" class="is-hidden">external site</p>
+                <font-awesome-icon icon="external-link-alt" aria-labelledby="enewsletter"></font-awesome-icon>
+              </span>
+            </a>
+          </span>
+          <span v-for="tag in reference.tags" :key="tag">
+            <span class="tag ml-2" v-if="tag.length > 0">{{tag}}</span>
+          </span>
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -33,3 +35,6 @@ export default {
   }
 }
 </script>
+<style lang="scss">
+  @import '@/assets/style/globals.scss'; 
+</style>

--- a/src/components/CveRecordReferences.vue
+++ b/src/components/CveRecordReferences.vue
@@ -3,9 +3,9 @@
     class="mt-5"
     style="word-break:break-all;"
   >
-    <h4 class="title mb-2">References <span class="tag">{{ references.length }} Total</span></h4>
-    <div class="cve-scroll-box p-5">
-      <ul>
+    <h4 class="title mb-3">References <span class="tag">{{ references.length }} Total</span></h4>
+    <div class="cve-scroll-box">
+      <ul class="mt-0">
         <li v-for="(reference, index) in references" :key="`link-${index}`" class="cve-word-wrap">
           <span class="icon-text">
             <a :href="reference.url" target="_blank">

--- a/src/components/ProductStatus.vue
+++ b/src/components/ProductStatus.vue
@@ -30,46 +30,47 @@
               </div>
             </nav>
             <div id="cve-affected-unaffected-unknown-versions">
-              <p class="cve-product-status-heading pb-1" style="border-bottom: 1px solid lightgray;">
+              <p class="cve-product-status-heading pb-1" >
                 Versions <span class="tag">{{ versionsCount(product) }} Total</span>
               </p>
-             
-              <div class="column is-12-desktop cve-versions-scroll mb-4">
-                <div id="cve-version-default-status">
-                  <p v-if="product.defaultStatus" class="cve-help-text is-italic">
-                    <span class="has-text-weight-bold">Default Status: </span>{{product.defaultStatus}}
-                  </p>
-                  <p v-else class="cve-help-text is-italic"><span class="has-text-weight-bold">Default Status: </span>unknown</p>
-                </div>
-                <div v-for="header in product.versionsColumns.headers" :key="header.key">
-                  <div :id="header" class="mt-1">
-                    <p style="text-transform: capitalize;">{{ header }}</p>
-                    <ul class="menu-list mt-1" v-for="row in product.versionsColumns.twoDTable[header]" :key="row.key">
-                      <li>
-                        <span v-if="row.versionsChanges.length > 0">
-                          <p>
-                            {{row.parentVersionStatus}}
-                            <span v-for="word in row.parentVersionRange" :key="word.key" :class="isAversion(word) ? 'cve-version' : ''">{{word}}&nbsp;</span>
-                          </p>
-                          <ul style="border-left: none !important;">
-                            <li v-for="change in row.versionsChanges" :key="change.key">
-                              <span v-for="word in change" :key="word.key" :class="isAversion(word) ? 'cve-version' : ''">{{word}}&nbsp;</span>
-                            </li>
-                          </ul>
-                        </span>
-                        <span v-else>
-                          <span v-if="row.parentVersionRange.length > 0">{{row.parentVersionStatus}}
-                            <span v-for="word in row.parentVersionRange" :key="word.key" :class="isAversion(word) ? 'cve-version' : ''">{{word}}&nbsp;</span>
+              <div class="cve-scroll-box pt-3">
+                <div class="column is-12-desktop mb-4">
+                  <div id="cve-version-default-status">
+                    <p v-if="product.defaultStatus" class="cve-help-text is-italic">
+                      <span class="has-text-weight-bold">Default Status: </span>{{product.defaultStatus}}
+                    </p>
+                    <p v-else class="cve-help-text is-italic"><span class="has-text-weight-bold">Default Status: </span>unknown</p>
+                  </div>
+                  <div v-for="header in product.versionsColumns.headers" :key="header.key">
+                    <div :id="header" class="mt-1">
+                      <p style="text-transform: capitalize;">{{ header }}</p>
+                      <ul class="menu-list mt-1" v-for="row in product.versionsColumns.twoDTable[header]" :key="row.key">
+                        <li>
+                          <span v-if="row.versionsChanges.length > 0">
+                            <p>
+                              {{row.parentVersionStatus}}
+                              <span v-for="word in row.parentVersionRange" :key="word.key" :class="isAversion(word) ? 'cve-version' : ''">{{word}}&nbsp;</span>
+                            </p>
+                            <ul style="border-left: none !important;">
+                              <li v-for="change in row.versionsChanges" :key="change.key">
+                                <span v-for="word in change" :key="word.key" :class="isAversion(word) ? 'cve-version' : ''">{{word}}&nbsp;</span>
+                              </li>
+                            </ul>
                           </span>
                           <span v-else>
-                            {{row.parentVersionStatus}} {{row.parentVersionRange}}
+                            <span v-if="row.parentVersionRange.length > 0">{{row.parentVersionStatus}}
+                              <span v-for="word in row.parentVersionRange" :key="word.key" :class="isAversion(word) ? 'cve-version' : ''">{{word}}&nbsp;</span>
+                            </span>
+                            <span v-else>
+                              {{row.parentVersionStatus}} {{row.parentVersionRange}}
+                            </span>
                           </span>
-                        </span>
-                      </li>
-                    </ul>
+                        </li>
+                      </ul>
+                    </div>
                   </div>
                 </div>
-              </div>
+            </div>
             </div>
             <!-- <div id="cve-cpes" v-if="product.cpes.length > 0">
               <p class="cve-product-status-heading" style="border-bottom: 1px solid lightgray;">CPEs</p>
@@ -176,12 +177,6 @@ export default {
 }
 .level-item {
   justify-content: left!important;
-}
-
-.cve-versions-scroll {
-  max-height: 15rem;
-  border-bottom: 1px solid lightgray;
-  overflow-y: scroll;
 }
  </style>
   

--- a/src/components/ProductStatus.vue
+++ b/src/components/ProductStatus.vue
@@ -33,7 +33,7 @@
               <p class="cve-product-status-heading pb-1" >
                 Versions <span class="tag">{{ versionsCount(product) }} Total</span>
               </p>
-              <div class="cve-scroll-box pt-3">
+              <div class="cve-scroll-box pt-1">
                 <div class="column is-12-desktop mb-4">
                   <div id="cve-version-default-status">
                     <p v-if="product.defaultStatus" class="cve-help-text is-italic">


### PR DESCRIPTION
## Summary
Added scrolling and borders to the References section of the published CVE record view. This styling matches other potentially long sections in the CVE record view, like versions.

Also, centralized related styling and SCSS to be global and reused across related sections.

![Screenshot 2024-10-18 at 11 59 09 AM](https://github.com/user-attachments/assets/5117fa07-a484-4e02-a993-0a556f4db2d9)

![Screenshot 2024-10-18 at 1 03 27 PM](https://github.com/user-attachments/assets/a0347f4f-3e4c-47ed-8e1f-7e60d0aa1fdb)


**Important Changes**

`src/components/CveRecordReferences.vue`
- Added `cve-scroll-box` to add scrolling and border styling
- Added tag displaying total reference count

`src/components/AdpVulnerabilityEnrichment.vue` 
- Globalized certain scroll styling from existing scroll containers



