### PR TITLE
Resolves #2927 correct anchor in link for source control versions in user guide (dev branch)

### DIFF
--- a/src/views/CVERecord/CveRecordUserGuide.vue
+++ b/src/views/CVERecord/CveRecordUserGuide.vue
@@ -236,7 +236,7 @@
               </li>
               <li>
                 For a non-linear version example view the
-                <a href="https://github.com/CVEProject/cve-schema/blob/main/schema/docs/versions.md#versions-and-version-ranges" target="_blank">
+                <a href="https://github.com/CVEProject/cve-schema/blob/main/schema/docs/versions.md#source-control-versions" target="_blank">
                   Source Control Versions
                 </a>
                 section


### PR DESCRIPTION
Changed the incorrect URL anchor from `versions-and-version-ranges` to `source-control-versions` in `CveRecordUserGuide.vue`.  Confirmed that the changed anchor brings up the correct section ("Source Control Versions") in the document.