### PR TITLE
Resolves #2926 prevent Description heading from scrolling with text (dev branch)

### DIFF
--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -125,9 +125,9 @@
             </nav>
           </div>
 
-          <div id="cve-desciption" class="content cve-x-scroll">
+          <div id="cve-description">
             <h4 class="title is-size-5">Description</h4>
-            <p v-for="description in cveFieldList.descriptions" :key="description">{{description}}</p>
+            <p class="content cve-x-scroll" v-for="description in cveFieldList.descriptions" :key="description">{{description}}</p>
           </div>
         </div>
         <div v-if="roleName !== 'cveProgram'">


### PR DESCRIPTION
The **Description** header under the **CNA** tab scrolled along with the description text if a very long URL was included in the text.  This was corrected by removing the header from the `cve-x-scroll` class, so that only the paragraph containing the text is scrollable.  This was tested by launching the sample CVE record and manually adding a very long URL into the description text, long enough to create a scrollbar.  The **Description** header remains fixed (doesn't scroll).