### PR TITLE
Resolves #2911 Dev version of PR #3222

### DIFF
--- a/src/components/AdpVulnerabilityEnrichment.vue
+++ b/src/components/AdpVulnerabilityEnrichment.vue
@@ -407,11 +407,14 @@ export default {
       }
     },
     getCveProgramReferences(){
-      if (this.containerObject.providerMetadata.shortName.toLowerCase() !== usecveRecordStore().cveProgramShortName) return;
+      if (this.containerObject.providerMetadata.shortName?.toLowerCase() !== usecveRecordStore().cveProgramShortName) return;
       this.cveProgramReferences = usecveRecordStore().getReferences(this.containerObject.references);
     },
     getUpdatedDate() {
-      this.dateUpdated = this.getDate(this.containerObject.providerMetadata.dateUpdated);
+      if(this.containerObject.providerMetadata?.dateUpdated) {
+        this.dateUpdated = this.getDate(this.containerObject.providerMetadata?.dateUpdated);
+      }
+    
     },
     getDate(dateTime) {
       const [date] = dateTime.split('T');


### PR DESCRIPTION
## Summary

Added checks to account for situations when a record doesn't have `providerMetadata` fields. These fields are technically not required by the schema, but are generated by CVE-Services when records are published, EXCEPT for records created by the Secretariat endpoint. So this change accounts specifically for that edge case.

![Screenshot 2024-10-25 at 12 04 54 PM](https://github.com/user-attachments/assets/e5e6d8d2-5ab7-4fb9-8f1b-7e8db89fc67a)

**Important Changes**
`src/components/AdpVulnerabilityEnrichment.vue`
- Added check for missing providerMetadata

