### PR TITLE
Resolves #2964 remove expand button (+) from Program Organization -> Structure (int-main)

### DIFF
--- a/src/assets/data/navigation.json
+++ b/src/assets/data/navigation.json
@@ -151,8 +151,7 @@
       "Structure": {
         "id": "3.0",
         "label": "Structure",
-        "path": "Structure",
-        "items": {}
+        "path": "Structure"
       },
       "Program Relationship with Partners": {
         "id": "3.1",
@@ -168,7 +167,7 @@
             "label": "External Partners"
           },
           "Additional Resources": {
-            "anchorId": "AdditonalResources",
+            "anchorId": "AdditionalResources",
             "label": "Additional Resources"
           }
         }


### PR DESCRIPTION
After a lot of searching and experimenting, it all boiled down to removing the "items" element from the "Structure" object in `navigation.json`.  I also made a spelling correction that has no reference elsewhere.  I've tested that the `Structure` entry in the `Program Organization` navigation sidebar has no expand button.
