### PR TITLE
#3258 dynamically updates tab title to reflect searched cve record

### DIFF
--- a/src/components/cveRecordLookupModule.vue
+++ b/src/components/cveRecordLookupModule.vue
@@ -131,7 +131,7 @@ export default {
         this.resetStates();
         useCveRecordLookupStore().cveId = this.cveId;
         const newPath = `/CVERecord?id=${useCveRecordLookupStore().cveId}`;
-        this.$router.push(newPath);
+        this.$router.push({path: newPath, query: {id: useCveRecordLookupStore().cveId }});
         this.lookupId()
       }
     },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -398,6 +398,10 @@ const router = createRouter({
 
 // This callback runs before every route change, including on page load.
 router.beforeEach((to, from, next) => {
+  //Changes title to reflect CVE-ID 
+  if (to.name === "CVERecord") {
+      to.meta.title = to.query.id + "| CVE"
+  }
   // This goes through the matched routes from last to first, finding the closest route with a title.
   // e.g., if we have `/some/deep/nested/route` and `/some`, `/deep`, and `/nested` have titles,
   // `/nested`'s will be chosen.


### PR DESCRIPTION
## Summary
When viewing a record, the browser tab title will now update to include the CVE-ID being viewed.

<img width="234" alt="Screenshot 2024-11-25 at 3 55 19 PM" src="https://github.com/user-attachments/assets/5e6ed475-9f27-42ef-80a3-dadf4817bf30">

**Important Changes**

`src/components/cveRecordLookupModule.vue`
- Passed CVE-ID in router.query object

`src/router/index.js`
- Added logic in `beforeEach` navigation guard to update the title for the CVERecord route