### PR TITLE
Resolves #1910 - Downloads Navigation Sidebar Width Correction (dev)

### DIFF
--- a/src/views/Downloads.vue
+++ b/src/views/Downloads.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="cve-secondary-page-main-container">
+  <div id="cve-secondary-page-main-container" class="container">
     <div class="columns is-centered">
       <div class="column is-8-desktop cve-main-column-content-width is-12-tablet">
         <main id="cve-main-page-content" role="main">


### PR DESCRIPTION
The width of the navigation sidebar on the Downloads page was larger than the equivalent sidebars on the other pages.  I was able to correct the width on this page by adding a missing class attribute.