### PR TITLE
Resolves #3314 fix CNA long name in Search Results page (dev)

### DIFF
--- a/src/stores/cveListSearch.js
+++ b/src/stores/cveListSearch.js
@@ -112,6 +112,7 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
         let recordDataSummary = {
           cveId: cveRecordData?.cveMetadata?.cveId || 'No ID provided',
           cna: cveRecordData?.cveMetadata?.assignerShortName || 'No CNA provided',
+          cnaOrgId: cveRecordData?.cveMetadata?.orgId || '',
           descriptions: descriptions,
           relevancyScore: 'not appliciable'
         }
@@ -167,6 +168,7 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
           parsedResults.push({
             cveId: result._id,
             cna: result?._source?.cveMetadata?.assignerShortName || 'No CNA provided',
+            cnaOrgId: result?._source?.cveMetadata?.orgId || '', 
             descriptions: this.processDescriptionsField(result),
             relevancyScore: result?._score
           });

--- a/src/views/CVERecord/SearchResults.vue
+++ b/src/views/CVERecord/SearchResults.vue
@@ -46,8 +46,7 @@
                             <router-link :to="`/CVERecord?id=${cveListSearchStore.recordData.cveId}`" target="_blank">{{ cveListSearchStore.recordData.cveId }}</router-link>
                           </div>
                           <div class="column cve-column">
-                            <p><span>CNA: </span>{{ usePartnerStore?.[cveListSearchStore.recordData.cna] || cveListSearchStore.recordData.cna }}</p>
-                            <p></p>
+                            <p><span>CNA: </span>{{ usePartnerStore[cveListSearchStore.recordData.cna] ? usePartnerStore[cveListSearchStore.recordData.cna] : cveListSearchStore.recordData.cna }}</p>
                           </div>
                         </div>
                         <div class="columns cve-columns">
@@ -132,7 +131,7 @@
                                 <router-link :to="`/CVERecord?id=${result.cveId}`" target="_blank">{{ result.cveId }}</router-link>
                               </div>
                               <div class="column cve-column">
-                                <p><span>CNA: </span>{{ usePartnerStore?.[result.cna] || result.cna }}</p>
+                                <p><span>CNA: </span>{{ usePartnerStore[result.cnaOrgId] ? usePartnerStore[result.cnaOrgId] : result.cna }}</p>
                                 <p></p>
                               </div>
                             </div>


### PR DESCRIPTION
# Summary
The "CNA" fields on the Search Results page is unexpectedly not rendering the CNA long name, rather just the CNA short name else, "No CNA provided."

**Important Changes**
src/stores/cveListSearch.js
- Added `cnaOrgId` to get the org id for the individual records in the search results or when a CVE Record is Found

src/views/CVERecord/SearchResults.vue
- Update rendering logic to check if the `cnaOrgId` exists in the `usePartnerStore`, then display the corresponding CNA long name, else display the CNA short name or "No CNA provided." if the short name does not exist.