### PR TITLE
Resolves #2821 Fixes scrolling to anchors

### DIFF
--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -1,82 +1,82 @@
 <template>
   <div ref="tableRef" class="table-container">
-    <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable" >
+    <table aria-live="polite" class="table cve-border-dark-blue is-striped is-hoverable">
       <thead>
         <tr>
-          <th v-for="(header, index) in tableHeaders" :key="index">{{header}}</th>
+          <th v-for="(header, index) in tableHeaders" :key="index">{{ header }}</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(entry, index) in tableData" :key="index"
+        <tr
+          v-for="(entry, index) in tableData"
+          :key="index"
           :id="entry.id"
           :ref="entry.id"
           v-on:click="selectRow(entry.id)"
-          
-          v-bind:class="{'cve-term-active': selectedRow === entry.id}">
+          v-bind:class="{ 'cve-term-active': selectedRow === entry.id }"
+        >
           <td class="table-column-width">
-              <a :href="entry.termLink" v-bind:class="{'selectTermLink': selectedRow === entry.id}" class="has-text-weight-bold termLink"> {{ entry.term }} </a>
+            <router-link
+              :to="'#' + entry.id"
+              v-bind:class="{ selectTermLink: selectedRow === entry.id }"
+              class="has-text-weight-bold termLink"
+            >
+              {{ entry.term }}
+            </router-link>
           </td>
-          <td v-if="renderAsHTML" class="cve-term-definition" v-html="entry.definition"> </td>
-          <td v-else class="cve-term-definition">{{ entry.definition }} </td>
+          <td
+            v-if="renderAsHTML"
+            class="cve-term-definition"
+            v-html="entry.definition"
+          ></td>
+          <td v-else class="cve-term-definition">{{ entry.definition }}</td>
         </tr>
       </tbody>
     </table>
   </div>
-  </template>
-  
-  <script>
+</template>
 
-  export default {
-    name: "SearchTable",
-    props: {
-      tableData: {
-        type: Array,
-        required: true,
-      },
-      tableHeaders: {
-        type: Array,
-        required: true,
-      },
-      renderAsHTML: {
-        type: Boolean,
-        default: false,
-        required: false,
-      }
+<script>
+export default {
+  name: "SearchTable",
+  props: {
+    tableData: {
+      type: Array,
+      required: true,
     },
-    data() {
-      return {
-       selectedRow: null 
-      };
+    tableHeaders: {
+      type: Array,
+      required: true,
     },
-    mounted() {
-      let term = null;
+    renderAsHTML: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
+  },
+  data() {
+    return {
+      selectedRow: null,
+    };
+  },
+  mounted() {
+    let term = null;
 
-        // Add active term as a hash to scroll to it then select it
-      if (this.$route.query.activeTerm) {
-            term = this.$route.query.activeTerm;
-            this.$router.push({hash: "#" + term })
-            this.selectRow(term)
-      }
-      // If route already has a hash, just select the term
-      else if (this.$route.hash) {
-            term = this.$route.hash.slice(1);
-            this.selectRow(term)
-      }
+    if (this.$route.hash) {
+      term = this.$route.hash.slice(1);
+      this.selectRow(term);
+    }
+  },
+  methods: {
+    selectRow(rowId) {
+      this.selectedRow = rowId;
     },
-    methods: {
-      selectRow(rowId) {
-        
-          this.selectedRow = (rowId === this.selectedRow ? null : rowId)
-      }
-    },
-  };
-  </script>
-  
-  <!-- Add "scoped" attribute to limit CSS to this component only -->
+  },
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
-  
-@import '@/assets/style/routerLink.scss';
-
 @media only screen and (min-width: $desktop) {
   .table-column-width {
     width: 30% !important;
@@ -85,18 +85,19 @@
 
 .cve-term-active {
   background-color: $theme-color-accent-cool-light !important;
-  color: black ;
-  padding-left: 8px; 
+  color: black;
+  padding-left: 8px;
   padding-top: 5px;
   padding-bottom: 5px;
 }
-  
+
 .termLink {
   color: $theme-color-primary;
+  background: unset;
+  // scroll-margin: 50px;
 }
 
 .selectTermLink {
   color: black;
 }
 </style>
-   

--- a/src/components/SearchTable.vue
+++ b/src/components/SearchTable.vue
@@ -94,7 +94,6 @@ export default {
 .termLink {
   color: $theme-color-primary;
   background: unset;
-  // scroll-margin: 50px;
 }
 
 .selectTermLink {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -45,16 +45,24 @@ import NotFound from '@/views/NotFound.vue';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  scrollBehavior(to) {
-    if (to.hash) {
-      return {
-        el: to.hash,
-        top: 55
-      };
-    }
-    return {
-      top: 0
-    };
+  scrollBehavior(to) {  
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        if (to.hash) {
+          resolve({
+            el: to.hash,
+            top: 55,
+            behavior: "instant"
+          });
+        }
+        resolve({
+          top: 0
+        });
+      }, 0)
+    
+    })
+
+   
   },
   routes: [
     {
@@ -212,6 +220,12 @@ const router = createRouter({
       component: Glossary,
       meta: {
         title: 'Glossary | CVE',
+      },
+      beforeEnter: (to) => {
+        if (!to.hash) {
+          const term = to.query.activeTerm;
+          to.hash = '#' + term
+        }
       },
     },
     {

--- a/src/views/ResourcesSupport/AllResources/CNARules.vue
+++ b/src/views/ResourcesSupport/AllResources/CNARules.vue
@@ -18,9 +18,9 @@
               Effective Date: <span>{{ versionDate }}</span>
             </p>
             <p>
-              <router-link to="/Resources/Roles/Cnas/CNA_Rules_v4.0.pdf" target="_blank"
-                >View as PDF (0.2MB)</router-link
-              >
+              <router-link to="/Resources/Roles/Cnas/CNA_Rules_v4.0.pdf" target="_blank">
+                View as PDF (0.2MB)
+              </router-link>
             </p>
           </div>
           <hr />

--- a/src/views/ResourcesSupport/AllResources/CNARules.vue
+++ b/src/views/ResourcesSupport/AllResources/CNARules.vue
@@ -2,76 +2,119 @@
   <div id="cve-tertiary-page-main-container" class="container">
     <div class="columns is-centered">
       <div class="column is-3 is-hidden-touch">
-        <TableOfContentsSidebar :nav="cvePageNavs"/>
+        <TableOfContentsSidebar :nav="cvePageNavs" />
       </div>
       <div class="column is-8-desktop cve-main-column-content-width is-12-tablet">
         <main id="cve-main-page-content" role="main">
           <h1 class="title">CVE Numbering Authority (CNA) Operational Rules</h1>
           <div id="cve-versionInformation">
-            <p class="has-text-weight-bold">Document Version: <span>{{versionNum}}</span></p>
-            <p class="has-text-weight-bold">CVE Board Approval: <span>{{versionApprovalDate}}</span></p>
-            <p class="has-text-weight-bold">Effective Date: <span>{{versionDate}}</span></p>
-            <p><router-link to="/Resources/Roles/Cnas/CNA_Rules_v4.0.pdf" target="_blank">View as PDF (0.2MB)</router-link></p>
+            <p class="has-text-weight-bold">
+              Document Version: <span>{{ versionNum }}</span>
+            </p>
+            <p class="has-text-weight-bold">
+              CVE Board Approval: <span>{{ versionApprovalDate }}</span>
+            </p>
+            <p class="has-text-weight-bold">
+              Effective Date: <span>{{ versionDate }}</span>
+            </p>
+            <p>
+              <router-link to="/Resources/Roles/Cnas/CNA_Rules_v4.0.pdf" target="_blank"
+                >View as PDF (0.2MB)</router-link
+              >
+            </p>
           </div>
-          <hr>
+          <hr />
           <!-- Top level section -->
           <div class="content">
             <ol class="ml-0">
               <li v-for="(section, index) of cnaRulesSections" :key="index">
                 <h2 class="title" :id="section.sectionId">
-                  {{ section.sectionTitle }}
+                  <a :href="`#${section.sectionId}`">
+                    {{ section.sectionTitle }}
+                  </a>
                 </h2>
-                <p v-for="(para, index) of section.sectionParagraphs" v-html="para" :key="index"></p>
+                <p
+                  v-for="(para, index) of section.sectionParagraphs"
+                  v-html="para"
+                  :key="index"
+                ></p>
                 <!-- Sub section -->
                 <ol class="ml-0">
                   <li v-for="(subSection, index) of section.subSections" :key="index">
                     <h3 class="title" :id="subSection.subSectionId">
-                      {{ subSection.subSectionTitle }}
+                      <a :href="`#${subSection.subSectionId}`">
+                        {{ subSection.subSectionTitle }}
+                      </a>
                     </h3>
-                      <p v-for="(para, index) of subSection.subSectionParagraphs"
-                      v-html="para" :key="index"></p>
+                    <p
+                      v-for="(para, index) of subSection.subSectionParagraphs"
+                      v-html="para"
+                      :key="index"
+                    ></p>
                   </li>
-                </ol>  <!-- end page sub section -->
+                </ol>
+                <!-- end page sub section -->
               </li>
-            </ol> <!-- end page section -->
+            </ol>
+            <!-- end page section -->
             <ul class="ml-0 cve-list-no-bullet">
               <li v-for="(section, index) of cnaRulesAppendices" :key="index">
                 <h2 class="title" :id="section.sectionId">
                   {{ section.sectionTitle }}
                 </h2>
-                <p v-for="(para, index) of section.sectionParagraphs" v-html="para" :key="index"></p>
+                <p
+                  v-for="(para, index) of section.sectionParagraphs"
+                  v-html="para"
+                  :key="index"
+                ></p>
                 <!-- Sub section -->
                 <ul class="ml-0 cve-list-no-bullet">
                   <li v-for="(subSection, index) of section.subSections" :key="index">
                     <h3 class="title" :id="subSection.subSectionId">
-                       {{ subSection.subSectionTitle }}
+                      {{ subSection.subSectionTitle }}
                     </h3>
-                    <p v-for="(para, index) of subSection.subSectionParagraphs" v-html="para" :key="index"></p>
-                    <ul class="ml-0 cve-list-no-bullet"> <!-- Sub Sub section -->
-                      <li v-for="(subSubSection, index) of subSection.subSubSections" :key="index">
+                    <p
+                      v-for="(para, index) of subSection.subSectionParagraphs"
+                      v-html="para"
+                      :key="index"
+                    ></p>
+                    <ul class="ml-0 cve-list-no-bullet">
+                      <!-- Sub Sub section -->
+                      <li
+                        v-for="(subSubSection, index) of subSection.subSubSections"
+                        :key="index"
+                      >
                         <h4 class="title" :id="subSubSection.subSubSectionId">
                           {{ subSubSection.subSubSectionTitle }}
                         </h4>
-                        <p v-for="(para, index) of subSubSection.subSubSectionParagraphs" v-html="para" :key="index"></p>
+                        <p
+                          v-for="(para, index) of subSubSection.subSubSectionParagraphs"
+                          v-html="para"
+                          :key="index"
+                        ></p>
                       </li>
-                    </ul> <!-- end apendices sub sub section -->
+                    </ul>
+                    <!-- end apendices sub sub section -->
                   </li>
-                </ul>  <!-- end appendices sub section -->
+                </ul>
+                <!-- end appendices sub section -->
               </li>
-            </ul> <!-- end appendicessection -->
-         </div>
+            </ul>
+            <!-- end appendicessection -->
+          </div>
         </main>
       </div>
-    </div>             <!-- end columns -->
+    </div>
+    <!-- end columns -->
   </div>
 </template>
 
 <script>
-import TableOfContentsSidebar from '@/components/TableOfContentsSidebar.vue';
-import cnaRulesData from '@/assets/data/cnaRules.json';
+import TableOfContentsSidebar from "@/components/TableOfContentsSidebar.vue";
+import cnaRulesData from "@/assets/data/cnaRules.json";
 
 export default {
-  name: 'CNARules',
+  name: "CNARules",
   components: {
     TableOfContentsSidebar,
   },
@@ -89,21 +132,28 @@ export default {
 </script>
 
 <style lang="scss">
-@import '@/assets/style/globals.scss';
+@import "@/assets/style/globals.scss";
 </style>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+ol {
+  counter-reset: item;
+}
+ol li {
+  display: block;
+}
 
-ol { counter-reset: item; }
-ol li {display: block;}
-ol li p, ul li p {
+ol li p,
+ul li p {
   margin-bottom: 16px;
 }
-ol li h2::before, ol li h3::before {
+ol li h2 a::before,
+ol li h3 a::before {
   content: counters(item, ".");
   counter-increment: item;
   margin-right: 0.5rem;
+  color: #005ea2;
 }
 
 :deep(.cve-acronym),


### PR DESCRIPTION
# Summary
Scrolling to anchors on certain pages like Glossary and CNA Rules would sometimes scroll the target anchor out of view. This specifically happened when navigating to the sight externally. 

Also, this updates the CNA Rules page to have links directly on each section title and not just in the table of contents.

![Screenshot 2024-12-11 at 1 32 46 PM](https://github.com/user-attachments/assets/d9ad1c71-06a4-4c55-9cb7-f83e259e7a19)


**Important Changes**
`index.js`
- Specified `scrollBehavior`
- Wrapped behavior in promise and added `setTimeout` of 0. This works.
- Added navigation guard for the glossary route to update the route hash when activeTerm is used instead.

`SearchTable.vue`
- Replaced `<a>` with `vue-router`
- updated behavior to not reload the page when clicking on a term
- simplified `mount()` behavior

`cnaRules.vue`
- Added anchors to each section and subsection
- Added CSS to make each `li` counter clickable
