### PR TITLE
#3340 fix CNA long name and update CNA shortname (dev)

### DIFF
--- a/src/stores/cveListSearch.js
+++ b/src/stores/cveListSearch.js
@@ -111,8 +111,8 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
         });
         let recordDataSummary = {
           cveId: cveRecordData?.cveMetadata?.cveId || 'No ID provided',
-          cna: cveRecordData?.cveMetadata?.assignerShortName || 'No CNA provided',
-          cnaOrgId: cveRecordData?.cveMetadata?.orgId || '',
+          cna: cveRecordData?.containers?.cna.providerMetadata.shortName || 'No CNA provided',
+          cnaOrgId: cveRecordData?.containers?.cna.providerMetadata.orgId || '',
           descriptions: descriptions,
           relevancyScore: 'not appliciable'
         }
@@ -164,15 +164,16 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
 
       if (results.length >> 0) {
         results.forEach((result) => {
-
           parsedResults.push({
             cveId: result._id,
-            cna: result?._source?.cveMetadata?.assignerShortName || 'No CNA provided',
-            cnaOrgId: result?._source?.cveMetadata?.orgId || '', 
+            cna: result?._source?.containers?.cna.providerMetadata.shortName || 'No CNA provided',
+            cnaOrgId: result?._source?.containers?.cna.providerMetadata.orgId || '',
             descriptions: this.processDescriptionsField(result),
             relevancyScore: result?._score
           });
         });
+      console.log('parsedResults.cna', parsedResults)
+        
       }
 
       this.searchResults = parsedResults;

--- a/src/stores/cveListSearch.js
+++ b/src/stores/cveListSearch.js
@@ -172,7 +172,6 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
             relevancyScore: result?._score
           });
         });
-      console.log('parsedResults.cna', parsedResults)
         
       }
 

--- a/src/stores/cveListSearch.js
+++ b/src/stores/cveListSearch.js
@@ -111,8 +111,8 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
         });
         let recordDataSummary = {
           cveId: cveRecordData?.cveMetadata?.cveId || 'No ID provided',
-          cna: cveRecordData?.containers?.cna.providerMetadata.shortName || 'No CNA provided',
-          cnaOrgId: cveRecordData?.containers?.cna.providerMetadata.orgId || '',
+          cna: cveRecordData?.containers?.cna?.providerMetadata?.shortName || 'No CNA provided',
+          cnaOrgId: cveRecordData?.containers?.cna?.providerMetadata?.orgId || '',
           descriptions: descriptions,
           relevancyScore: 'not appliciable'
         }
@@ -166,8 +166,8 @@ export const useCveListSearchStore = defineStore('cveListSearch ', {
         results.forEach((result) => {
           parsedResults.push({
             cveId: result._id,
-            cna: result?._source?.containers?.cna.providerMetadata.shortName || 'No CNA provided',
-            cnaOrgId: result?._source?.containers?.cna.providerMetadata.orgId || '',
+            cna: result?._source?.containers?.cna?.providerMetadata?.shortName || 'No CNA provided',
+            cnaOrgId: result?._source?.containers?.cna?.providerMetadata?.orgId || '',
             descriptions: this.processDescriptionsField(result),
             relevancyScore: result?._score
           });

--- a/src/views/CVERecord/SearchResults.vue
+++ b/src/views/CVERecord/SearchResults.vue
@@ -46,7 +46,9 @@
                             <router-link :to="`/CVERecord?id=${cveListSearchStore.recordData.cveId}`" target="_blank">{{ cveListSearchStore.recordData.cveId }}</router-link>
                           </div>
                           <div class="column cve-column">
-                            <p><span>CNA: </span>{{ usePartnerStore[cveListSearchStore.recordData.cna] ? usePartnerStore[cveListSearchStore.recordData.cna] : cveListSearchStore.recordData.cna }}</p>
+                            <p>
+                              <span>CNA: </span>
+                              {{ partnerStore.partnerShortLongNameMap[cveListSearchStore.recordData.cnaOrgId] ? partnerStore.partnerShortLongNameMap[cveListSearchStore.recordData.cnaOrgId] : cveListSearchStore.recordData.cna }}</p>
                           </div>
                         </div>
                         <div class="columns cve-columns">
@@ -131,8 +133,10 @@
                                 <router-link :to="`/CVERecord?id=${result.cveId}`" target="_blank">{{ result.cveId }}</router-link>
                               </div>
                               <div class="column cve-column">
-                                <p><span>CNA: </span>{{ usePartnerStore[result.cnaOrgId] ? usePartnerStore[result.cnaOrgId] : result.cna }}</p>
-                                <p></p>
+                                <p>
+                                  <span>CNA: </span>
+                                  {{ partnerStore.partnerShortLongNameMap[result.cnaOrgId] ? partnerStore.partnerShortLongNameMap[result.cnaOrgId] : result.cna }}
+                                </p>
                               </div>
                             </div>
                             <div class="columns cve-columns">
@@ -252,6 +256,7 @@ import { useRouter } from 'vue-router';
 import ServiceUnavailable from '@/components/ServiceUnavailable.vue'
 
 const cveListSearchStore = useCveListSearchStore();
+const partnerStore = usePartnerStore();
 const router = useRouter();
 const app = createApp({});
 const resultUrl = ref(`https://${import.meta.env.VITE_CVE_SERVICES_BASE_URL}`);


### PR DESCRIPTION
# Summary
Please see description for issue #3340. It's a continuation of #3314.

**Important Changes**
src/stores/cveListSearch.js
- `cna` and `cnaOrgId` switched to using the `containers.cna.providerMetadata` `shortName` and `orgId` properties

src/views/CVERecord/SearchResults.vue
- created `partnerStore` object and accessing `partnerShortLongNameMap` property to get CNA long name by Id.

**UI**
Same as #3314