### PR TITLE
Resolves #3017 - Correct Render CNA Names (dev)

### DIFF
--- a/src/views/CVERecord/PublishedRecord.vue
+++ b/src/views/CVERecord/PublishedRecord.vue
@@ -61,7 +61,7 @@
               <h2 class="title">Required CVE Record Information</h2>
               <AdpVulnerabilityEnrichment v-if="Object.keys(cnaContainer).length > 0" role="cna" :selectedCnaData="cveFieldList"
                 :containerObject="cnaContainer" :orgId="`cna-${cnaContainer.providerMetadata.orgId}`" :anchorId="cnaContainer.onPageMenu.anchorId">
-                <h1 class="mb-1 has-text-white cve-capitalize-first-letter">
+                <h1 class="mb-1 has-text-white">
                   <span v-if="!isLoading">{{ cnaContainer.onPageMenu.label }} </span>
                   <span v-else>
                     <span class="icon">


### PR DESCRIPTION
Removed the capitalization of "words" in the CNA name displayed in the returned record.  The displayed CNA name is as it exists in the database.
Closes #3017 
