### PR TITLE
Resolves #3081 - metrics: fix tables in mobile view (int)

### DIFF
--- a/src/views/About/Metrics.vue
+++ b/src/views/About/Metrics.vue
@@ -710,8 +710,33 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
-//Equally space data cells in metrics tables
+
+// Equally space data cells in metrics tables
+// Numbers in metrics tables look better right-aligned.
+
 td {
   width: auto !important;
+  text-align: right !important;
 }
+
+// For the mobile screen sizes, this overrides the settings in cveTableStacked,
+// which was causing tables to be split into multiple tables and the year
+// headings to be hidden.  This keeps the tables intact.  Mobile users will
+// be able to horizontally scroll as normal.
+
+@media only screen and (max-width: $desktop) {
+
+  td {
+    display: table-cell;
+  }
+
+  thead th {
+    display: table-cell;
+  }
+
+  tr {
+    display: table-row !important;
+  }
+}
+
 </style>


### PR DESCRIPTION
This change overrides the CSS for tables in cveTableStacked.scss, which is really meant for tables used like a "bordered section of content" - see the Resources page.  The metrics page is truly tabular data and the style doesn't work in mobile views.  The CSS added to the Metrics module reverses the effect and displays the tables the same in mobile view as in a full desktop view.  Horizontal scrolling is used if the table it too large for the display area.

Closes #3081
Closes #2900