### PR TITLE
Make Heights for Access, Learn, Report/Request Titles Consistent

### DIFF
--- a/src/components/HomeModule.vue
+++ b/src/components/HomeModule.vue
@@ -33,7 +33,7 @@
             <div class="tile is-ancestor cve-task-tiles-container">
               <div class="tile is-parent cve-task-access-tile">
                 <article class="tile is-child cve-border-dark-blue">
-                  <h3 class="title cve-task-tile-header">
+                  <h3 class="title is-5 cve-task-tile-header">
                     <span class="icon is-medium is-block cve-task-tile-icon"><font-awesome-icon :icon="['far', 'arrow-alt-circle-right']" /></span>
                     Access
                   </h3>
@@ -68,7 +68,7 @@
               </div>
               <div class="tile is-parent cve-task-learn-tile">
                 <article class="tile is-child cve-border-dark-blue">
-                  <h3 class="title cve-task-tile-header">
+                  <h3 class="title is-5 cve-task-tile-header">
                     <span class="icon is-medium is-block cve-task-tile-icon"><font-awesome-icon :icon="['fab', 'leanpub']"/></span>
                     Learn
                   </h3>
@@ -91,7 +91,7 @@
               </div>
               <div class="tile is-parent cve-task-report-tile">
                 <article class="tile is-child cve-border-dark-blue">
-                  <h3 class="title is-4 cve-task-tile-header">
+                  <h3 class="title is-5 cve-task-tile-header">
                     <span class="icon is-medium is-block cve-task-tile-icon"><font-awesome-icon :icon="['far', 'clipboard']" /></span>
                     Report/Request
                   </h3>


### PR DESCRIPTION
I found that the "Report/Request" section in the home page had a different title height (via CSS class) than the Access & Learn sections.  I've made the heights all consistent and it looks good on the non-mobile window sizes.
