### PR TITLE
SEO: add "unhead" for meta; add title, heading, & description (TEST)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" type="image/x-icon" href="/cvePurpleVFavicon.svg">
-    <title>CVE Website</title>
+    <link rel="canonical" href="https://cve.org">
     <script src="https://cmp.osano.com/AzyhULTdPkqmy4aDN/46057d56-0263-4cca-abac-9adddada4f3b/osano.js"></script>
   </head>
   <body class="has-navbar-fixed-top">
+    <h1 hidden>Common vulnerabilities and Exposures (CVE)</h1>
     <noscript>
       <strong>We're sorry but the CVE Website doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/vue-fontawesome": "^3.0.5",
+        "@unhead/vue": "^1.11.18",
         "axios": "^1.6.5",
         "bulma": "^0.9.4",
         "bulma-timeline": "^3.0.5",
@@ -1792,6 +1793,63 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@unhead/dom": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.11.18.tgz",
+      "integrity": "sha512-zQuJUw/et9zYEV0SZWTDX23IgurwMaXycAuxt4L6OgNL0T4TWP3a0J/Vm3Q02hmdNo/cPKeVBrwBdnFUXjGU4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.18",
+        "@unhead/shared": "1.11.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/schema": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.11.18.tgz",
+      "integrity": "sha512-a3TA/OJCRdfbFhcA3Hq24k1ZU1o9szicESrw8DZcGyQFacHnh84mVgnyqSkMnwgCmfN4kvjSiTBlLEHS6+wATw==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3",
+        "zhead": "^2.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/shared": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.11.18.tgz",
+      "integrity": "sha512-OsupRQRxJqqnuKiL1Guqipjbl7MndD5DofvmGa3PFGu2qNPmOmH2mxGFjRBBgq2XxY1KalIHl/2I9HV6gbK8cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.18",
+        "packrup": "^0.1.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/vue": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.11.18.tgz",
+      "integrity": "sha512-Jfi7t/XNBnlcauP9UTH3VHBcS69G70ikFd2e5zdgULLDRWpOlLs1sSTH1V2juNptc93DOk9RQfC5jLWbLcivFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.18",
+        "@unhead/shared": "1.11.18",
+        "hookable": "^5.5.3",
+        "unhead": "1.11.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=2.7 || >=3"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.6.2",
@@ -3608,6 +3666,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -4924,6 +4988,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/packrup": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/packrup/-/packrup-0.1.2.tgz",
+      "integrity": "sha512-ZcKU7zrr5GlonoS9cxxrb5HVswGnyj6jQvwFBa6p5VFw7G71VAHcUKL5wyZSU/ECtPM/9gacWxy2KFQKt1gMNA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6037,6 +6110,21 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "node_modules/unhead": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.11.18.tgz",
+      "integrity": "sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/dom": "1.11.18",
+        "@unhead/schema": "1.11.18",
+        "@unhead/shared": "1.11.18",
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -6470,6 +6558,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zhead": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
+      "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
       }
     }
   },
@@ -7593,6 +7690,44 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@unhead/dom": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.11.18.tgz",
+      "integrity": "sha512-zQuJUw/et9zYEV0SZWTDX23IgurwMaXycAuxt4L6OgNL0T4TWP3a0J/Vm3Q02hmdNo/cPKeVBrwBdnFUXjGU4w==",
+      "requires": {
+        "@unhead/schema": "1.11.18",
+        "@unhead/shared": "1.11.18"
+      }
+    },
+    "@unhead/schema": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.11.18.tgz",
+      "integrity": "sha512-a3TA/OJCRdfbFhcA3Hq24k1ZU1o9szicESrw8DZcGyQFacHnh84mVgnyqSkMnwgCmfN4kvjSiTBlLEHS6+wATw==",
+      "requires": {
+        "hookable": "^5.5.3",
+        "zhead": "^2.2.4"
+      }
+    },
+    "@unhead/shared": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.11.18.tgz",
+      "integrity": "sha512-OsupRQRxJqqnuKiL1Guqipjbl7MndD5DofvmGa3PFGu2qNPmOmH2mxGFjRBBgq2XxY1KalIHl/2I9HV6gbK8cw==",
+      "requires": {
+        "@unhead/schema": "1.11.18",
+        "packrup": "^0.1.2"
+      }
+    },
+    "@unhead/vue": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.11.18.tgz",
+      "integrity": "sha512-Jfi7t/XNBnlcauP9UTH3VHBcS69G70ikFd2e5zdgULLDRWpOlLs1sSTH1V2juNptc93DOk9RQfC5jLWbLcivFw==",
+      "requires": {
+        "@unhead/schema": "1.11.18",
+        "@unhead/shared": "1.11.18",
+        "hookable": "^5.5.3",
+        "unhead": "1.11.18"
+      }
     },
     "@vitejs/plugin-vue": {
       "version": "4.6.2",
@@ -8944,6 +9079,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
+    },
     "hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -9932,6 +10072,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "packrup": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/packrup/-/packrup-0.1.2.tgz",
+      "integrity": "sha512-ZcKU7zrr5GlonoS9cxxrb5HVswGnyj6jQvwFBa6p5VFw7G71VAHcUKL5wyZSU/ECtPM/9gacWxy2KFQKt1gMNA=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10696,6 +10841,17 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "unhead": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.11.18.tgz",
+      "integrity": "sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==",
+      "requires": {
+        "@unhead/dom": "1.11.18",
+        "@unhead/schema": "1.11.18",
+        "@unhead/shared": "1.11.18",
+        "hookable": "^5.5.3"
+      }
+    },
     "unique-filename": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -10978,6 +11134,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zhead": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
+      "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/vue-fontawesome": "^3.0.5",
+    "@unhead/vue": "^1.11.18",
     "axios": "^1.6.5",
     "bulma": "^0.9.4",
     "bulma-timeline": "^3.0.5",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Disallow: /*.pdf$
+Disallow: /*.jpg$
+Disallow: /*.png$
+Disallow: /*.svg$
+Disallow: /*.css$
+Disallow: /images/
+Disallow: /Resources/

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@ import NotificationBannerModule from './components/NotificationBannerModule.vue'
 import FoooterModule from './components/FooterModule.vue';
 import NotFound from './views/NotFound.vue';
 import { usePartnerStore } from '@/stores/partners';
+import { useSeoMeta } from '@unhead/vue';
 
 export default {
   components: {
@@ -35,6 +36,12 @@ export default {
   },
   beforeMount() {
     usePartnerStore().populatePartnerShortLongNameMap();
+    useSeoMeta({
+      title: 'CVE: Common Vulnerabilities and Exposures',
+      description: 'At cve.org, we provide the authoritative '
+        + 'reference method for publicly known information-security '
+        + 'vulnerabilities and exposures'
+    });
   }
 }
 </script>

--- a/src/components/HomeModule.vue
+++ b/src/components/HomeModule.vue
@@ -21,7 +21,9 @@
               </div>
               <div class="column cve-partnership-right-column">
                 <figure class="image">
-                  <img src="@/assets/images/cvePartnershipGraphic.svg" class="cve-partnership-img" alt=""/>
+                  <img src="@/assets/images/cvePartnershipGraphic.svg"
+                    class="cve-partnership-img"
+                    alt="CVE Partnership Graphic"/>
                 </figure>
               </div>
             </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 
 import { createApp } from 'vue';
+import { createHead, VueHeadMixin } from '@unhead/vue';
 import { createPinia } from 'pinia';
 import VueGtag from 'vue-gtag';
 import LoadScript from 'vue-plugin-load-script';
@@ -31,11 +32,14 @@ library.add(
 
 
 const app = createApp(App);
+const head = createHead();
 const pinia = createPinia();
 pinia.use(({ store }) => {
   store.router = router;
 });
 app.use(pinia);
+app.use(head);
+app.mixin(VueHeadMixin);
 
 usePartnerStore().populatePartnerCounts();
 


### PR DESCRIPTION
Added `unhead` package as a dependency for adding meta data to the header.
Used `unhead` to add title & description
Added canonical link for cve.org
Added alt text for CVE Partnership graphic
All the above were recommended by seobility.net & seoptimizer.com
First test in the TEST instance, where we'll run the analysis again.
