### PR TITLE
Resolves #3389 - Handle Plural of "results" in Summary

### DIFF
--- a/src/views/CVERecord/SearchResults.vue
+++ b/src/views/CVERecord/SearchResults.vue
@@ -125,7 +125,7 @@
                         <span class="has-text-weight-bold">
                           {{ cveListSearchStore.totalSearchResultCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') }}
                         </span>
-                        <span> results for </span>
+                        <span> result{{ cveListSearchStore.totalSearchResultCount == 1 ? '' : 's' }} for </span>
                         <span class="has-text-weight-bold">{{ cveListSearchStore.query }}</span>
                       </p>
                     </div>


### PR DESCRIPTION
The search page has a summary showing results like:

"Showing x of y results"

when the total is 1, the plural is still shown.  This change corrects this case.

Closes #3389