### PR TITLE
Board Meeting & Email Discussion Archives and Old Website Access

### DIFF
--- a/src/assets/data/boardMeetings.json
+++ b/src/assets/data/boardMeetings.json
@@ -1,6 +1,18 @@
 {
   "2025": [
     {
+      "name": "July 9, 2025 - teleconference",
+      "path": "msg00283.html"
+    },
+    {
+      "name": "June 25, 2025 - teleconference",
+      "path": "msg00277.html"
+    },
+    {
+      "name": "June 11, 2025 - teleconference",
+      "path": "msg00279.html"
+    },
+    {
       "name": "May 28, 2025 - teleconference",
       "path": "28_May_2025.pdf"
     },

--- a/src/assets/data/boardMeetings.json
+++ b/src/assets/data/boardMeetings.json
@@ -1,6 +1,22 @@
 {
   "2025": [
     {
+      "name": "May 28, 2025 - teleconference",
+      "path": "28_May_2025.pdf"
+    },
+    {
+      "name": "May 14, 2025 - teleconference",
+      "path": "14_May_2025.pdf"
+    },
+    {
+      "name": "April 30, 2025 - teleconference",
+      "path": "30_April_2025.pdf"
+    },
+    {
+      "name": "April 16, 2025 - teleconference",
+      "path": "16_April_2025.pdf"
+    },
+    {
       "name": "April 2, 2025 - teleconference",
       "path": "02_April_2025.pdf"
     },

--- a/src/assets/data/boardMeetings.json
+++ b/src/assets/data/boardMeetings.json
@@ -1,6 +1,10 @@
 {
   "2025": [
     {
+      "name": "July 23, 2025 - teleconference",
+      "path": "msg00286.html"
+    },
+    {
       "name": "July 9, 2025 - teleconference",
       "path": "msg00283.html"
     },
@@ -891,7 +895,7 @@
       "path": "2001-07/msg00000.html"
     },
     {
-      "name": "March 15-16, 2001 - face-to-face meeting at Cisco in Austin, Texas, USA",
+      "name": "March 15, 2001 - face-to-face meeting at Cisco in Austin, Texas, USA",
       "path": "2001-03/msg00014.html"
     },
     {
@@ -901,7 +905,7 @@
   ],
   "2000": [
     {
-      "name": "August 14-15, 2000 - face-to-face meeting at USENIX Security Symposium in Denver, Colorado, USA",
+      "name": "August 14, 2000 - face-to-face meeting at USENIX Security Symposium in Denver, Colorado, USA",
       "path": "2000-08/msg00013.html"
     },
     {
@@ -909,7 +913,7 @@
       "path": "2000-07/msg00000.html"
     },
     {
-      "name": "March 9-10, 2000 - face-to-face meeting at AXENT in Salt Lake City, Utah, USA",
+      "name": "March 9, 2000 - face-to-face meeting at AXENT in Salt Lake City, Utah, USA",
       "path": "2000-03/msg00007.html"
     }
   ],

--- a/src/assets/data/boardMeetings.json
+++ b/src/assets/data/boardMeetings.json
@@ -1,0 +1,910 @@
+{
+  "2025": [
+    {
+      "name": "April 2, 2025 - teleconference",
+      "path": "02_April_2025.pdf"
+    },
+    {
+      "name": "March 5, 2025 - teleconference",
+      "path": "05_March_2025.pdf"
+    },
+    {
+      "name": "February 19, 2025 - teleconference",
+      "path": "19_February_2025.pdf"
+    },
+    {
+      "name": "February 5, 2025 - teleconference",
+      "path": "05_February_2025.pdf"
+    },
+    {
+      "name": "January 22, 2025 - teleconference",
+      "path": "22_January_2025.pdf"
+    },
+    {
+      "name": "January 8, 2025 - teleconference",
+      "path": "08_January_2025.pdf"
+    }
+  ],
+  "2024": [
+    {
+      "name": "December 11, 2024 - teleconference",
+      "path": "11_December_2024.pdf"
+    },
+    {
+      "name": "November 13, 2024 - teleconference",
+      "path": "13_November_2024.pdf"
+    },
+    {
+      "name": "October 30, 2024 - teleconference",
+      "path": "30_October_2024.pdf"
+    },
+    {
+      "name": "October 16, 2024 - teleconference",
+      "path": "16_October_2024.pdf"
+    },
+    {
+      "name": "October 2, 2024 - teleconference",
+      "path": "02_October_2024.pdf"
+    },
+    {
+      "name": "September 18, 2024 - teleconference",
+      "path": "18_September_2024.pdf"
+    },
+    {
+      "name": "September 4, 2024 - teleconference",
+      "path": "04_September_2024.pdf"
+    },
+    {
+      "name": "August 21, 2024 - teleconference",
+      "path": "21_August_2024.pdf"
+    },
+    {
+      "name": "August 7, 2024 - teleconference",
+      "path": "07_August_2024.pdf"
+    },
+    {
+      "name": "July 24, 2024 - teleconference",
+      "path": "24_July_2024.pdf"
+    },
+    {
+      "name": "July 10, 2024 - teleconference",
+      "path": "10_July_2024.pdf"
+    },
+    {
+      "name": "June 26, 2024 - teleconference",
+      "path": "26_June_2024.pdf"
+    },
+    {
+      "name": "June 12, 2024 - teleconference",
+      "path": "12_June_2024.pdf"
+    },
+    {
+      "name": "May 29, 2024 - teleconference",
+      "path": "29_May_2024.pdf"
+    },
+    {
+      "name": "May 15, 2024 - teleconference",
+      "path": "15_May_2024.pdf"
+    },
+    {
+      "name": "May 1, 2024 - teleconference",
+      "path": "01_May_2024.pdf"
+    },
+    {
+      "name": "April 17, 2024 - teleconference",
+      "path": "17_April_2024.pdf"
+    },
+    {
+      "name": "April 3, 2024 - teleconference",
+      "path": "03_April_2024.pdf"
+    },
+    {
+      "name": "March 20, 2024 - teleconference",
+      "path": "20_March_2024.pdf"
+    },
+    {
+      "name": "March 6, 2024 - teleconference",
+      "path": "06_March_2024.pdf"
+    },
+    {
+      "name": "February 21, 2024 - teleconference",
+      "path": "21_February_2024.pdf"
+    },
+    {
+      "name": "February 7, 2024 - teleconference",
+      "path": "07_February_2024.pdf"
+    },
+    {
+      "name": "January 24, 2024 - teleconference",
+      "path": "24_January_2024.pdf"
+    }
+  ],
+  "2023": [
+    {
+      "name": "December 13, 2023 - teleconference",
+      "path": "13_December_2023.pdf"
+    },
+    {
+      "name": "November 29, 2023 - teleconference",
+      "path": "29_November_2023.pdf"
+    },
+    {
+      "name": "November 8, 2023 - teleconference",
+      "path": "08_November_2023.pdf"
+    },
+    {
+      "name": "October 25, 2023 - teleconference",
+      "path": "25_October_2023.pdf"
+    },
+    {
+      "name": "October 11, 2023 - teleconference",
+      "path": "11_October_2023.pdf"
+    },
+    {
+      "name": "September 27, 2023 - teleconference",
+      "path": "27_September_2023.pdf"
+    },
+    {
+      "name": "September 13, 2023 - teleconference",
+      "path": "13_September_2023.pdf"
+    },
+    {
+      "name": "August 30, 2023 - teleconference",
+      "path": "30_August_2023.pdf"
+    },
+    {
+      "name": "August 16, 2023 - teleconference",
+      "path": "16_August_2023.pdf"
+    },
+    {
+      "name": "July 19, 2023 - teleconference",
+      "path": "19_July_2023.pdf"
+    },
+    {
+      "name": "June 21, 2023 - teleconference",
+      "path": "21_June_2023.pdf"
+    },
+    {
+      "name": "May 24, 2023 - teleconference",
+      "path": "24_May_2023.pdf"
+    },
+    {
+      "name": "May 3, 2023 - teleconference",
+      "path": "03_May_2023.pdf"
+    },
+    {
+      "name": "April 12, 2023 - teleconference",
+      "path": "12_April_2023.pdf"
+    },
+    {
+      "name": "March 29, 2023 - teleconference",
+      "path": "29_March_2023.pdf"
+    },
+    {
+      "name": "March 15, 2023 - teleconference",
+      "path": "15_March_2023.pdf"
+    },
+    {
+      "name": "March 1, 2023 - teleconference",
+      "path": "01_March_2023.pdf"
+    },
+    {
+      "name": "February 15, 2023 - teleconference",
+      "path": "15_February_2023.pdf"
+    },
+    {
+      "name": "February 1, 2023 - teleconference",
+      "path": "01_February_2023.pdf"
+    },
+    {
+      "name": "January 18, 2023 - teleconference",
+      "path": "18_January_2023.pdf"
+    },
+    {
+      "name": "January 4, 2023 - teleconference",
+      "path": "04_January_2023.pdf"
+    }
+  ],
+  "2022": [
+    {
+      "name": "December 14, 2022 - teleconference",
+      "path": "14_December_2022.pdf"
+    },
+    {
+      "name": "November 30, 2022 - teleconference",
+      "path": "30_November_2022.pdf"
+    },
+    {
+      "name": "November 9, 2022 - teleconference",
+      "path": "09_November_2022.pdf"
+    },
+    {
+      "name": "October 26, 2022 - teleconference",
+      "path": "26_October_2022.pdf"
+    },
+    {
+      "name": "October 12, 2022 - teleconference",
+      "path": "12_October_2022.pdf"
+    },
+    {
+      "name": "September 28, 2022 - teleconference",
+      "path": "28_September_2022.pdf"
+    },
+    {
+      "name": "September 14, 2022 - teleconference",
+      "path": "14_September_2022.pdf"
+    },
+    {
+      "name": "August 31, 2022 - teleconference",
+      "path": "31_August_2022.pdf"
+    },
+    {
+      "name": "August 17, 2022 - teleconference",
+      "path": "17_August_2022.pdf"
+    },
+    {
+      "name": "August 3, 2022 - teleconference",
+      "path": "03_August_2022.pdf"
+    },
+    {
+      "name": "July 20, 2022 - teleconference",
+      "path": "20_July_2022.pdf"
+    },
+    {
+      "name": "July 6, 2022 - teleconference",
+      "path": "06_July_2022.pdf"
+    },
+    {
+      "name": "June 22, 2022 - teleconference",
+      "path": "22_June_2022.pdf"
+    },
+    {
+      "name": "May 25, 2022 - teleconference",
+      "path": "25_May_2022.pdf"
+    },
+    {
+      "name": "May 11, 2022 - teleconference",
+      "path": "11_May_2022.pdf"
+    },
+    {
+      "name": "April 27, 2022 - teleconference",
+      "path": "27_April_2022.pdf"
+    },
+    {
+      "name": "March 30, 2022 - teleconference",
+      "path": "30_March_2022.pdf"
+    },
+    {
+      "name": "March 16, 2022 - teleconference",
+      "path": "16_March_2022.pdf"
+    },
+    {
+      "name": "March 2, 2022 - teleconference",
+      "path": "02_March_2022.pdf"
+    },
+    {
+      "name": "February 16, 2022 - teleconference",
+      "path": "16_February_2022.pdf"
+    },
+    {
+      "name": "February 2, 2022 - teleconference",
+      "path": "02_February_2022.pdf"
+    },
+    {
+      "name": "January 19, 2022 - teleconference",
+      "path": "19_January_2022.pdf"
+    },
+    {
+      "name": "January 5, 2022 - teleconference",
+      "path": "05_January_2022.pdf"
+    }
+  ],
+  "2021": [
+    {
+      "name": "December 8, 2021 - teleconference",
+      "path": "08_December_2021.pdf"
+    },
+    {
+      "name": "November 10, 2021 - teleconference",
+      "path": "10_November_2021.pdf"
+    },
+    {
+      "name": "October 13, 2021 - teleconference",
+      "path": "13_October_2021.pdf"
+    },
+    {
+      "name": "September 29, 2021 - teleconference",
+      "path": "29_September_2021.pdf"
+    },
+    {
+      "name": "September 15, 2021 - teleconference",
+      "path": "15_September_2021.pdf"
+    },
+    {
+      "name": "September 1, 2021 - teleconference",
+      "path": "01_September_2021.pdf"
+    },
+    {
+      "name": "August 18, 2021 - teleconference",
+      "path": "18_August_2021.pdf"
+    },
+    {
+      "name": "August 4, 2021 - teleconference",
+      "path": "04_August_2021.pdf"
+    },
+    {
+      "name": "July 21, 2021 - teleconference",
+      "path": "21_July_2021.pdf"
+    },
+    {
+      "name": "July 7, 2021 - teleconference",
+      "path": "07_July_2021.pdf"
+    },
+    {
+      "name": "June 23, 2021 - teleconference",
+      "path": "23_June_2021.pdf"
+    },
+    {
+      "name": "June 9, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "May 26, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 28, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 14, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "March 31, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "March 17, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "March 3, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "February 17, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "February 3, 2021 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "January 6, 2021 - teleconference",
+      "path": ""
+    }
+  ],
+  "2020": [
+    {
+      "name": "December 16, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "December 2, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "November 18, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "November 4, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "October 28, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "October 14, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "September 30, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "August 19, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "August 5, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "July 22, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "July 8, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "June 24, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "June 10, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "May 27, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "May 13, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 29, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 15, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 1, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "March 18, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "February 19, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "February 5, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "January 22, 2020 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "January 8, 2020 - teleconference",
+      "path": ""
+    }
+  ],
+  "2019": [
+    {
+      "name": "December 11, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "November 13, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "October 30, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "October 16, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "October 2, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "September 4, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "August 21, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "July 24, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "July 10, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "June 26, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "June 12, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "May 29, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "May 15, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "May 1, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 17, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "April 3, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "March 20, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "February 6, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "January 23, 2019 - teleconference",
+      "path": ""
+    },
+    {
+      "name": "January 9, 2019 - teleconference",
+      "path": ""
+    }
+  ],
+  "2018": [
+    {
+      "name": "December 12, 2018 - teleconference",
+      "path": "2019-01/msg00004.html"
+    },
+    {
+      "name": "November 28, 2018 - teleconference",
+      "path": "2018-12/msg00002.html"
+    },
+    {
+      "name": "November 14, 2018 - teleconference",
+      "path": "2018-12/msg00000.html"
+    },
+    {
+      "name": "October 31, 2018 - teleconference",
+      "path": "2018-11/msg00003.html"
+    },
+    {
+      "name": "October 17, 2018 - teleconference",
+      "path": "2018-10/msg00017.html"
+    },
+    {
+      "name": "October 3, 2018 - teleconference",
+      "path": "2018-10/msg00013.html"
+    },
+    {
+      "name": "September 19, 2018 - teleconference",
+      "path": "2018-10/msg00004.html"
+    },
+    {
+      "name": "September 5, 2018 - teleconference",
+      "path": "2018-09/msg00005.html"
+    },
+    {
+      "name": "August 22, 2018 - teleconference",
+      "path": "2018-08/msg00026.html"
+    },
+    {
+      "name": "August 8, 2018 - teleconference",
+      "path": "2018-08/msg00019.html"
+    },
+    {
+      "name": "July 25, 2018 - teleconference",
+      "path": "2018-07/msg00013.html"
+    },
+    {
+      "name": "July 11, 2018 - teleconference",
+      "path": "2018-07/msg00009.html"
+    },
+    {
+      "name": "June 27, 2018 - teleconference",
+      "path": "2018-07/msg00000.html"
+    },
+    {
+      "name": "June 13, 2018 - teleconference",
+      "path": "2018-06/msg00003.html"
+    },
+    {
+      "name": "May 30, 2018 - teleconference",
+      "path": "2018-06/msg00000.html"
+    },
+    {
+      "name": "May 16, 2018 - teleconference",
+      "path": "2018-05/msg00025.html"
+    },
+    {
+      "name": "May 2, 2018 - teleconference",
+      "path": "2018-05/msg00010.html"
+    },
+    {
+      "name": "April 25, 2018 - teleconference",
+      "path": "2018-05/msg00008.html"
+    },
+    {
+      "name": "April 4, 2018 - teleconference",
+      "path": "2018-04/msg00017.html"
+    },
+    {
+      "name": "March 21, 2018 - teleconference",
+      "path": "2018-03/msg00025.html"
+    },
+    {
+      "name": "March 7, 2018 - teleconference",
+      "path": "2018-03/msg00024.html"
+    },
+    {
+      "name": "February 21, 2018 - teleconference",
+      "path": "2018-03/msg00009.html"
+    },
+    {
+      "name": "February 7, 2018 - teleconference",
+      "path": "2018-03/msg00001.html"
+    },
+    {
+      "name": "January 24, 2018 - teleconference",
+      "path": "2018-02/msg00000.html"
+    },
+    {
+      "name": "January 10, 2018 - teleconference",
+      "path": "2018-01/msg00018.html"
+    }
+  ],
+  "2017": [
+    {
+      "name": "December 13, 2017 - teleconference",
+      "path": "2017-12/msg00032.html"
+    },
+    {
+      "name": "November 29, 2017 - teleconference",
+      "path": "2017-12/msg00025.html"
+    },
+    {
+      "name": "November 15, 2017 - teleconference",
+      "path": "2017-11/msg00044.html"
+    },
+    {
+      "name": "November 1, 2017 - teleconference",
+      "path": "2017-11/msg00025.html"
+    },
+    {
+      "name": "October 18, 2017 - teleconference",
+      "path": "2017-10/msg00062.html"
+    },
+    {
+      "name": "October 4, 2017 - teleconference",
+      "path": "2017-10/msg00032.html"
+    },
+    {
+      "name": "September 20, 2017 - teleconference",
+      "path": "2017-09/msg00056.html"
+    },
+    {
+      "name": "September 6, 2017 - teleconference",
+      "path": "2017-09/msg00028.html"
+    },
+    {
+      "name": "August 23, 2017 - teleconference",
+      "path": "2017-09/msg00001.html"
+    },
+    {
+      "name": "August 9, 2017 - teleconference",
+      "path": "2017-08/msg00016.html"
+    },
+    {
+      "name": "July 26, 2017 - teleconference",
+      "path": "2017-08/msg00000.html"
+    },
+    {
+      "name": "July 12, 2017 - teleconference",
+      "path": "2017-07/msg00069.html"
+    },
+    {
+      "name": "June 28, 2017 - teleconference",
+      "path": "2017-07/msg00067.html"
+    },
+    {
+      "name": "May 24, 2017 - teleconference",
+      "path": "2017-08/msg00002.html"
+    },
+    {
+      "name": "May 3, 2017 - teleconference",
+      "path": "2017-05/msg00082.html"
+    },
+    {
+      "name": "April 5, 2017 - teleconference",
+      "path": "2017-04/msg00021.html"
+    },
+    {
+      "name": "March 22, 2017 - teleconference",
+      "path": "2017-04/msg00003.html"
+    },
+    {
+      "name": "March 8, 2017 - teleconference",
+      "path": "2017-03/msg00032.html"
+    },
+    {
+      "name": "February 22, 2017 - teleconference",
+      "path": "2017-03/msg00016.html"
+    },
+    {
+      "name": "February 8, 2017 - teleconference",
+      "path": "2017-03/msg00017.html"
+    },
+    {
+      "name": "January 25, 2017 - teleconference",
+      "path": "2017-02/msg00009.html"
+    },
+    {
+      "name": "January 11, 2017 - teleconference",
+      "path": "2017-01/msg00046.html"
+    }
+  ],
+  "2016": [
+    {
+      "name": "December 14, 2016 - teleconference",
+      "path": "2016-12/msg00024.html"
+    },
+    {
+      "name": "November 30, 2016 - teleconference",
+      "path": "2016-12/msg00001.html"
+    },
+    {
+      "name": "November 16, 2016 - teleconference",
+      "path": "2016-12/msg00000.html"
+    },
+    {
+      "name": "November 2, 2016 - teleconference",
+      "path": "2016-11/msg00010.html"
+    },
+    {
+      "name": "October 19, 2016 - teleconference",
+      "path": "2016-11/msg00001.html"
+    },
+    {
+      "name": "October 5, 2016 - teleconference",
+      "path": "2016-10/msg00042.html"
+    },
+    {
+      "name": "September 21, 2016 - teleconference",
+      "path": "2016-10/msg00003.html"
+    },
+    {
+      "name": "August 25, 2016 - teleconference",
+      "path": "2016-09/msg00004.html"
+    },
+    {
+      "name": "August 11, 2016 - teleconference",
+      "path": "2016-08/msg00013.html"
+    },
+    {
+      "name": "July 28, 2016 - teleconference",
+      "path": "2016-08/msg00000.html"
+    },
+    {
+      "name": "July 14, 2016 - teleconference",
+      "path": "2016-07/msg00005.html"
+    },
+    {
+      "name": "June 30, 2016 - teleconference",
+      "path": "2016-07/msg00001.html"
+    },
+    {
+      "name": "June 2, 2016 - teleconference",
+      "path": "2016-06/msg00024.html"
+    },
+    {
+      "name": "May 19, 2016 - teleconference",
+      "path": "2016-06/msg00001.html"
+    },
+    {
+      "name": "May 5, 2016 - teleconference",
+      "path": "2016-05/msg00019.html"
+    },
+    {
+      "name": "April 21, 2016 - teleconference",
+      "path": "2016-05/msg00004.html"
+    },
+    {
+      "name": "March 30, 2016 - teleconference",
+      "path": "2016-04/msg00007.html"
+    }
+  ],
+  "2015": [
+    {
+      "name": "April 22, 2015 - face-to-face meeting at St. Francis San Francisco on Union Square, San Francisco, California, USA",
+      "path": ""
+    }
+  ],
+  "2013": [
+    {
+      "name": "January 8, 2013 - teleconference",
+      "path": "2013-02/msg00013.html"
+    }
+  ],
+  "2012": [
+    {
+      "name": "October 31, 2012 - teleconference",
+      "path": "2012-11/msg00012.html"
+    }
+  ],
+  "2011": [
+    {
+      "name": "November 19, 2011 - Future of Global Vulnerability Reporting track at Information Technology Security Automation Conference (ITSAC) 2011",
+      "path": "2011-11/msg00000.html"
+    }
+  ],
+  "2006": [
+    {
+      "name": "June 28, 2006 - teleconference",
+      "path": "2006-06/msg00000.html"
+    }
+  ],
+  "2001": [
+    {
+      "name": "September 27, 2001 - teleconference",
+      "path": "2001-10/msg00000.html"
+    },
+    {
+      "name": "June 21, 2001 - teleconference",
+      "path": "2001-07/msg00000.html"
+    },
+    {
+      "name": "March 15-16, 2001 - face-to-face meeting at Cisco in Austin, Texas, USA",
+      "path": "2001-03/msg00014.html"
+    },
+    {
+      "name": "January 18, 2001 - teleconference",
+      "path": "2001-01/msg00010.html"
+    }
+  ],
+  "2000": [
+    {
+      "name": "August 14-15, 2000 - face-to-face meeting at USENIX Security Symposium in Denver, Colorado, USA",
+      "path": "2000-08/msg00013.html"
+    },
+    {
+      "name": "June 29, 2000 - teleconference",
+      "path": "2000-07/msg00000.html"
+    },
+    {
+      "name": "March 9-10, 2000 - face-to-face meeting at AXENT in Salt Lake City, Utah, USA",
+      "path": "2000-03/msg00007.html"
+    }
+  ],
+  "1999": [
+    {
+      "name": "December 15, 1999 - teleconference",
+      "path": "1999-12/msg00020.html"
+    },
+    {
+      "name": "November 4, 1999 - teleconference",
+      "path": "1999-11/msg00010.html"
+    },
+    {
+      "name": "August 13, 1999 - face-to-face meeting at MITRE in Bedford, MA, USA",
+      "path": "1999-08/msg00036.html"
+    },
+    {
+      "name": "August 12, 1999 - face-to-face meeting at MITRE in Bedford, MA, USA",
+      "path": "1999-08/msg00034.html"
+    },
+    {
+      "name": "May 9, 1999 - \"Birds-of-a-feather\" meeting at the SANS conference in Baltimore, MD, USA",
+      "path": "1999-05/msg00013.html"
+    }
+  ]
+}

--- a/src/components/AccordionContent.vue
+++ b/src/components/AccordionContent.vue
@@ -1,0 +1,94 @@
+<!--
+This component is based on the Bulma message block, and was further taken from
+the "accordion" construct in the FAQ component (and other components in the
+CVE website code).  It contains a message header and expandable/collapsible
+message content.
+
+It is instantiated in a Vue template as follows:
+
+<AccordionContent header="<message-header>" ?is-expanded>
+    <message-body-content>
+</AccordionContent>
+
+where <message-header> is a short string used as a title, and "is-expanded"
+causes the content to be initially expanded.  By default, the message body
+content is collapsed.
+-->
+
+<template>
+    <nav class="message">
+        <div class="message-header cve-base-light-gray-borders-bg">
+            <p class="mt-2 mb-2">{{header}}</p>
+            <button class="button message-header-button"
+                @click="toggleAccordion()"
+                :aria-expanded="isVisible" :aria-controls="componentId">
+                <span class="icon is-small">
+                <p :id="buttonTextId" class="is-hidden">
+                    {{isVisible ? 'collapse' : 'expand'}}
+                </p>
+                <font-awesome-icon :icon="isVisible ? 'minus' : 'plus'"
+                    aria-hidden="false" focusable="true"
+                    :aria-labelledby="buttonTextId"/>
+                </span>
+            </button>
+        </div>
+        <div :id="messageBodyId" class="message-body"
+            :class="{'is-hidden': !isVisible}">
+            <slot></slot>
+        </div>
+    </nav>
+</template>
+
+<script>
+
+// Use with pre Vue 3.5 uuid implementation.  This has to be defined outside
+// of any instance.
+
+let uuid = 0;
+
+</script>
+
+<script setup>
+
+// Use useId() for generating unique ID per instance, in Vue 3.5+
+// import {ref, useId} from 'vue';
+import {onBeforeMount, ref} from 'vue';
+
+// const componentId = useId();
+
+let componentId = 0;
+
+let buttonTextId;
+let messageBodyId;
+
+const props = defineProps({
+    header: String,
+    isExpanded: Boolean
+});
+
+// const expandId = `expandCollapseAltText-${componentId}`;
+
+const isVisible = ref(props.isExpanded);
+
+onBeforeMount(() => {
+
+    // This establishes the unique identifier for each instance.  This will
+    // be replaced by the simpler useId() when we've upgraded to Vue 3.5+.
+    // At that point, there will be no need for the before mount callback.
+
+    uuid++;
+    componentId = uuid;
+    buttonTextId = `AccordionButtonText-${componentId}`;
+    messageBodyId = `AccordionBody-${componentId}`;
+});
+
+function toggleAccordion() {
+
+    isVisible.value = !isVisible.value;
+}
+
+</script>
+
+<style lang="scss">
+@import '@/assets/style/globals.scss';
+</style>

--- a/src/components/cveRecordSearchModule.vue
+++ b/src/components/cveRecordSearchModule.vue
@@ -62,7 +62,7 @@
           aria-labelledby="alertIcon" aria-hidden="false" />
           <ul class="pl-4" style="list-style: square">
             <li v-for="errorMsg in errorMessageStore.errorMessage"
-              class="cve-help-text" v-html="errorMsg"></li>
+              :key="errorMsg" class="cve-help-text" v-html="errorMsg"></li>
           </ul>
       </div>
     </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,6 +11,7 @@ import PartnerDetails from '@/views/PartnerInformation/PartnerDetails.vue';
 import Structure from '@/views/ProgramOrganization/Structure.vue';
 import ProgramRelationshipwithPartners from '@/views/ProgramOrganization/ProgramRelationshipwithPartners.vue';
 import Board from '@/views/ProgramOrganization/Board.vue';
+import BoardArchives from '@/views/ProgramOrganization/Archives.vue';
 import WorkingGroups from '@/views/ProgramOrganization/WorkingGroups.vue';
 import CNAs from '@/views/ProgramOrganization/CNAs.vue';
 import ADPs from '@/views/ProgramOrganization/ADPs.vue';
@@ -154,6 +155,14 @@ const router = createRouter({
       path: '/ProgramOrganization/Board',
       name: 'Board',
       component: Board,
+      meta: {
+        title: 'Board | CVE',
+      },
+    },
+    {
+      path: '/ProgramOrganization/BoardArchives',
+      name: 'BoardArchives',
+      component: BoardArchives,
       meta: {
         title: 'Board | CVE',
       },

--- a/src/views/ProgramOrganization/Archives.vue
+++ b/src/views/ProgramOrganization/Archives.vue
@@ -1,0 +1,292 @@
+<template>
+  <div id="cve-secondary-page-main-container">
+    <div class="columns is-centered">
+      <div class="column is-8-desktop cve-main-column-content-width is-12-tablet">
+        <main id="cve-main-page-content" role="main">
+          <div class="content">
+            <h1>Board Meetings & Discussion List Archives</h1>
+            <div>
+              <h2>Board Meeting Summaries Archive</h2>
+              <p>The CVE Board regularly holds teleconferences,
+                and periodically holds face-to-face meetings.
+                Below are summaries of the Board meetings.
+              </p>
+              <div v-for="year of Object.keys(meetingData).sort().reverse()"
+                  :key="year">
+                  <button class="button cve-button cve-button-base-color"
+                    @click="toggleYearList(year, yearFlags.expandYear)">
+                    {{ year }}
+                  </button>
+                  <Transition name="fade">
+                  <ul v-show="expandYear === year">
+                    <li v-for="item of meetingData[year]" :key="item.name">
+                      <div v-if="item.path.length">
+                        <a :href="archivePath + '/' + item.path">{{ item.name }}
+                        </a>
+                      </div>
+                      <span v-else>
+                        {{  item.name }}
+                      </span>
+                    </li>
+                  </ul>
+                  </Transition>
+                  <br>
+              </div>
+              <br>
+            </div>
+            <div>
+              <h2>Board Email Discussion List Archive</h2>
+              <p>
+                The CVE Board has made a commitment to make its discussions
+                available to the public. The following archives of Board
+                messages are available:
+              </p>
+              <form>
+                <div class="radios">
+                <span>Traverse discussions </span>
+                  <label class="radio">
+                    <input id="date" type="radio" name="discTraverse"
+                      v-model="traverse" value="date" checked />
+                    By Date
+                  </label>
+                  <label class="radio">
+                    <input id="thread" type="radio" name="discTraverse"
+                      v-model="traverse" value="thread" />
+                    By Thread
+                  </label>
+                </div>
+              </form>
+              <br>
+              <div v-for="year of discussionYears" :key="year">
+                  <button class="button cve-button cve-button-base-color"
+                    @click="toggleYearList(year, yearFlags.discYear)">
+                    {{ year }}
+                  </button>
+                  <Transition name="fade">
+                  <ul v-show="discYear === year">
+                    <li v-for="item of discussionData[year]" :key="item.month">
+                      <a :href="discussionURL(item)">{{ item.month }}</a>
+                    </li>
+                  </ul>
+                  </Transition>
+                  <br>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import meetingData from '@/assets/data/boardMeetings.json';
+import {ref} from 'vue';
+
+const archivePath = window.location.host + '/Resources/Media/Archives/Meetings'
+
+const discussionDirs = [
+  '1999-05',
+  '1999-06',
+  '1999-07',
+  '1999-08',
+  '1999-09',
+  '1999-10',
+  '1999-11',
+  '1999-12',
+  '2000-01',
+  '2000-02',
+  '2000-03',
+  '2000-04',
+  '2000-05',
+  '2000-06',
+  '2000-07',
+  '2000-08',
+  '2000-09',
+  '2000-10',
+  '2000-11',
+  '2000-12',
+  '2001-01',
+  '2001-02',
+  '2001-03',
+  '2001-04',
+  '2001-05',
+  '2001-06',
+  '2001-07',
+  '2001-08',
+  '2001-09',
+  '2001-10',
+  '2001-11',
+  '2001-12',
+  '2002-01',
+  '2002-02',
+  '2002-03',
+  '2002-05',
+  '2002-06',
+  '2002-07',
+  '2002-08',
+  '2002-10',
+  '2003-03',
+  '2003-04',
+  '2003-07',
+  '2004-03',
+  '2004-08',
+  '2004-09',
+  '2005-12',
+  '2006-06',
+  '2006-08',
+  '2006-09',
+  '2006-10',
+  '2007-01',
+  '2007-05',
+  '2011-09',
+  '2011-10',
+  '2011-11',
+  '2011-12',
+  '2012-01',
+  '2012-03',
+  '2012-05',
+  '2012-06',
+  '2012-07',
+  '2012-09',
+  '2012-10',
+  '2012-11',
+  '2012-12',
+  '2013-01',
+  '2013-02',
+  '2013-03',
+  '2013-04',
+  '2013-05',
+  '2013-06',
+  '2013-11',
+  '2014-01',
+  '2014-04',
+  '2014-05',
+  '2014-09',
+  '2014-10',
+  '2014-11',
+  '2015-01',
+  '2015-03',
+  '2015-04',
+  '2015-05',
+  '2015-06',
+  '2015-07',
+  '2015-08',
+  '2015-09',
+  '2015-10',
+  '2015-11',
+  '2015-12',
+  '2016-01',
+  '2016-02',
+  '2016-03',
+  '2016-04',
+  '2016-05',
+  '2016-06',
+  '2016-07',
+  '2016-08',
+  '2016-09',
+  '2016-10',
+  '2016-11',
+  '2016-12',
+  '2017-01',
+  '2017-02',
+  '2017-03',
+  '2017-04',
+  '2017-05',
+  '2017-06',
+  '2017-07',
+  '2017-08',
+  '2017-09',
+  '2017-10',
+  '2017-11',
+  '2017-12',
+  '2018-01',
+  '2018-02',
+  '2018-03',
+  '2018-04',
+  '2018-05',
+  '2018-06',
+  '2018-07',
+  '2018-08',
+  '2018-09',
+  '2018-10',
+  '2018-11',
+  '2018-12',
+  '2019-01'];
+
+const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
+  'August', 'September', 'October', 'November', 'December'];
+
+const discYear = ref();
+const expandYear = ref();
+
+const yearFlags = {
+  // This construct is used to be able to pass the refs to the toggleYearList().
+  // A ref is unwrapped if passed directly, but isn't if it's included in an
+  // object (https://github.com/vuejs/composition-api/issues/605).
+
+  discYear: discYear,
+  expandYear: expandYear
+}
+
+const traverse = ref('date');
+
+function toggleYearList(year, variable) {
+
+  console.log(variable.value);
+  variable.value = variable.value === year ? null : year;
+}
+
+function defaultDict(createValue) {
+    return new Proxy(Object.create(null), {
+        get(target, property) {
+            if (!(property in target))
+                target[property] = createValue(property);
+            return target[property];
+        }
+    });
+}
+
+function discussionURL(item) {
+  const url = archivePath + '/' + item.month + '/'
+    + (traverse.value == 'date' ? 'maillist.html' : 'threads.html');
+
+  return url;
+}
+
+function parseDiscussionDates(discussionData) {
+
+  for (let monthDir of discussionDirs.sort().reverse()) {
+
+    const match = /(?<year>\d{4})-(?<month>\d{2})/.exec(monthDir);
+
+    const year = match.groups.year;
+    const month = months[parseInt(match.groups.month, 10) - 1];
+
+    discussionData[year].push({month: month, dir: monthDir});
+  }
+}
+
+const discussionData = defaultDict(() => []);
+
+parseDiscussionDates(discussionData);
+
+const discussionYears = Object.keys(discussionData).sort().reverse();
+</script>
+
+<style lang="scss">
+@import '../../assets/style/globals.scss';
+</style>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped lang="scss">
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.5s;
+}
+
+.fade-enter, .fade-leave-to {
+  opacity: 0;
+}
+
+</style>

--- a/src/views/ProgramOrganization/Archives.vue
+++ b/src/views/ProgramOrganization/Archives.vue
@@ -20,7 +20,7 @@
               <ul>
                 <li v-for="item of meetingData[meetingYear]" :key="item.name">
                   <div v-if="item.path.length">
-                    <a :href="archivePath + '/' + item.path">{{item.name}}
+                    <a :href="meetingURL(item.path)">{{item.name}}
                     </a>
                   </div>
                   <span v-else>
@@ -33,7 +33,7 @@
               <p>
                 The CVE Board has made a commitment to make its discussions
                 available to the public. The following archives of Board
-                messages are available:
+                messages before February 2019 are available:
               </p>
               <form>
                 <div class="select">
@@ -68,7 +68,11 @@ import AccordionContent from '@/components/AccordionContent.vue';
 import meetingData from '@/assets/data/boardMeetings.json';
 import {ref} from 'vue';
 
-const archivePath = '/Resources/Media/Archives/Meetings'
+const archivePath = '/Resources/Media/Archives/OldWebsite/data/board/archives';
+
+const mailArchive = 'https://www.mail-archive.com';
+
+const meetingArchivePath = `${mailArchive}/cve-editorial-board-list@mitre.org`;
 
 // This is a list of directory names containing the email discussion archives.
 // The collection of these email discussions ended in 2019, so this list is
@@ -232,11 +236,25 @@ function defaultDict(createValue) {
 
 function discussionURL(item) {
 
-  // Given an item from 'meetingData', this returns the URL to either the
+  // Given an item from 'discussionData', this returns the URL to either the
   // by-date (maillist) or by-thread discussion traversal.
 
   const url = archivePath + '/' + item.dir + '/'
     + (traverse.value === 'date' ? 'maillist.html' : 'threads.html');
+
+  return url;
+}
+
+function meetingURL(name) {
+
+  // Given a file name of a board meeting summary, which is either a PDF file or
+  // an HTML file, this returns the URL to the meeting summary.  In 2025,
+  // the meeting summaries started being kept on a mail archive server, so
+  // if we're given an HTML file, we assume it's for the server; a PDF file
+  // is stored in the S3 archive path.
+
+  const url = (name.endsWith('.html') ? meetingArchivePath : archivePath)
+    + '/' + name;
 
   return url;
 }

--- a/src/views/ProgramOrganization/Archives.vue
+++ b/src/views/ProgramOrganization/Archives.vue
@@ -40,8 +40,7 @@
                 https://www.mail-archive.com/cve-editorial-board-list@mitre.org
                 </a>
                 </blockquote>
-                The following archives of Board messages before July 2021 are
-                available here:
+                Board messages before July 2021 are available here:
               </p>
               <form>
                 <div class="select">

--- a/src/views/ProgramOrganization/Archives.vue
+++ b/src/views/ProgramOrganization/Archives.vue
@@ -32,8 +32,16 @@
             <AccordionContent header="Board Email Discussion List Archive">
               <p>
                 The CVE Board has made a commitment to make its discussions
-                available to the public. The following archives of Board
-                messages before February 2019 are available:
+                available to the public. Board messages from July 2021 to the
+                present are available at:
+                <blockquote>
+                <a href="https://www.mail-archive.com/cve-editorial-board-list@mitre.org"
+                 target="_blank">
+                https://www.mail-archive.com/cve-editorial-board-list@mitre.org
+                </a>
+                </blockquote>
+                The following archives of Board messages before July 2021 are
+                available here:
               </p>
               <form>
                 <div class="select">
@@ -68,6 +76,12 @@ import AccordionContent from '@/components/AccordionContent.vue';
 import meetingData from '@/assets/data/boardMeetings.json';
 import {ref} from 'vue';
 
+// There are 2 locations for the board archives: the snapshot of the old
+// website (residing in S3), which is the "archivePath", and the "mail-archive"
+// website that stores the more recent archives.  Before 2021, the meeting
+// summaries are either PDF files or are HTML files in year/month-named
+// subdirectories - these reside in the S3 old website directories.
+
 const archivePath = '/Resources/Media/Archives/OldWebsite/data/board/archives';
 
 const mailArchive = 'https://www.mail-archive.com';
@@ -75,7 +89,7 @@ const mailArchive = 'https://www.mail-archive.com';
 const meetingArchivePath = `${mailArchive}/cve-editorial-board-list@mitre.org`;
 
 // This is a list of directory names containing the email discussion archives.
-// The collection of these email discussions ended in 2019, so this list is
+// The collection of these email discussions ended in 2021, so this list is
 // most likely never going to change, so it's defined here (rather than in
 // a separate data file).
 
@@ -206,7 +220,22 @@ const discussionDirs = [
   '2018-10',
   '2018-11',
   '2018-12',
-  '2019-01'];
+  '2019-01',
+  '2020-04',
+  '2020-05',
+  '2020-06',
+  '2020-07',
+  '2020-08',
+  '2020-09',
+  '2020-10',
+  '2020-11',
+  '2020-12',
+  '2021-01',
+  '2021-02',
+  '2021-03',
+  '2021-04',
+  '2021-05',
+  '2021-06'];
 
 const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
   'August', 'September', 'October', 'November', 'December'];
@@ -251,10 +280,11 @@ function meetingURL(name) {
   // an HTML file, this returns the URL to the meeting summary.  In 2025,
   // the meeting summaries started being kept on a mail archive server, so
   // if we're given an HTML file, we assume it's for the server; a PDF file
-  // is stored in the S3 archive path.
+  // is stored in the S3 archive path, as well as any HTML file that resides
+  // in a subdirectory.
 
-  const url = (name.endsWith('.html') ? meetingArchivePath : archivePath)
-    + '/' + name;
+  const url = (!name.includes('/') && name.endsWith('.html')
+    ? meetingArchivePath : archivePath) + '/' + name;
 
   return url;
 }

--- a/src/views/ProgramOrganization/Archives.vue
+++ b/src/views/ProgramOrganization/Archives.vue
@@ -5,73 +5,57 @@
         <main id="cve-main-page-content" role="main">
           <div class="content">
             <h1>Board Meetings & Discussion List Archives</h1>
-            <div>
-              <h2>Board Meeting Summaries Archive</h2>
+            <AccordionContent header="Board Meeting Summaries Archive">
               <p>The CVE Board regularly holds teleconferences,
                 and periodically holds face-to-face meetings.
                 Below are summaries of the Board meetings.
               </p>
-              <div v-for="year of Object.keys(meetingData).sort().reverse()"
-                  :key="year">
-                  <button class="button cve-button cve-button-base-color"
-                    @click="toggleYearList(year, yearFlags.expandYear)">
-                    {{ year }}
-                  </button>
-                  <Transition name="fade">
-                  <ul v-show="expandYear === year">
-                    <li v-for="item of meetingData[year]" :key="item.name">
-                      <div v-if="item.path.length">
-                        <a :href="archivePath + '/' + item.path">{{ item.name }}
-                        </a>
-                      </div>
-                      <span v-else>
-                        {{  item.name }}
-                      </span>
-                    </li>
-                  </ul>
-                  </Transition>
-                  <br>
+              <div class="select">
+                <select v-model="meetingYear">
+                  <option v-for="year of meetingYears" :key="year">
+                    {{year}}
+                  </option>
+                </select>
               </div>
-              <br>
-            </div>
-            <div>
-              <h2>Board Email Discussion List Archive</h2>
+              <ul>
+                <li v-for="item of meetingData[meetingYear]" :key="item.name">
+                  <div v-if="item.path.length">
+                    <a :href="archivePath + '/' + item.path">{{item.name}}
+                    </a>
+                  </div>
+                  <span v-else>
+                    {{item.name}}
+                  </span>
+                </li>
+              </ul>
+            </AccordionContent>
+            <AccordionContent header="Board Email Discussion List Archive">
               <p>
                 The CVE Board has made a commitment to make its discussions
                 available to the public. The following archives of Board
                 messages are available:
               </p>
               <form>
-                <div class="radios">
-                <span>Traverse discussions </span>
-                  <label class="radio">
-                    <input id="date" type="radio" name="discTraverse"
-                      v-model="traverse" value="date" checked />
-                    By Date
-                  </label>
-                  <label class="radio">
-                    <input id="thread" type="radio" name="discTraverse"
-                      v-model="traverse" value="thread" />
-                    By Thread
-                  </label>
+                <div class="select">
+                  <select v-model="discussionYear">
+                    <option v-for="year of discussionYears" :key="year">
+                      {{year}}
+                    </option>
+                  </select>
+                </div>
+                <div class="select">
+                  <select v-model="traverse">
+                    <option value="date" selected>By Date</option>
+                    <option value="thread">By Thread</option>
+                  </select>
                 </div>
               </form>
-              <br>
-              <div v-for="year of discussionYears" :key="year">
-                  <button class="button cve-button cve-button-base-color"
-                    @click="toggleYearList(year, yearFlags.discYear)">
-                    {{ year }}
-                  </button>
-                  <Transition name="fade">
-                  <ul v-show="discYear === year">
-                    <li v-for="item of discussionData[year]" :key="item.month">
-                      <a :href="discussionURL(item)">{{ item.month }}</a>
-                    </li>
-                  </ul>
-                  </Transition>
-                  <br>
-              </div>
-            </div>
+              <ul>
+                <li v-for="item of discussionData[discussionYear]" :key="item.month">
+                  <a :href="discussionURL(item)">{{item.month}}</a>
+                </li>
+              </ul>
+            </AccordionContent>
           </div>
         </main>
       </div>
@@ -80,10 +64,16 @@
 </template>
 
 <script setup>
+import AccordionContent from '@/components/AccordionContent.vue';
 import meetingData from '@/assets/data/boardMeetings.json';
 import {ref} from 'vue';
 
 const archivePath = window.location.host + '/Resources/Media/Archives/Meetings'
+
+// This is a list of directory names containing the email discussion archives.
+// The collection of these email discussions ended in 2019, so this list is
+// most likely never going to change, so it's defined here (rather than in
+// a separate data file).
 
 const discussionDirs = [
   '1999-05',
@@ -217,27 +207,20 @@ const discussionDirs = [
 const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July',
   'August', 'September', 'October', 'November', 'December'];
 
-const discYear = ref();
-const expandYear = ref();
+// Board meeting archives are presented by year, in reverse order from the
+// latest year available (which is likely the current year). 'meetingYear'
+// is the year the user is currently viewing.
 
-const yearFlags = {
-  // This construct is used to be able to pass the refs to the toggleYearList().
-  // A ref is unwrapped if passed directly, but isn't if it's included in an
-  // object (https://github.com/vuejs/composition-api/issues/605).
+const meetingYears = Object.keys(meetingData).sort().reverse();
 
-  discYear: discYear,
-  expandYear: expandYear
-}
-
-const traverse = ref('date');
-
-function toggleYearList(year, variable) {
-
-  console.log(variable.value);
-  variable.value = variable.value === year ? null : year;
-}
+const meetingYear = ref(meetingYears[0]);
 
 function defaultDict(createValue) {
+
+    // This is equivalent to Python's defaultdict, which allows a dictionary
+    // with a default value.  'createValue' is a callable that returns the
+    // default value for dictionary entries.
+
     return new Proxy(Object.create(null), {
         get(target, property) {
             if (!(property in target))
@@ -248,13 +231,22 @@ function defaultDict(createValue) {
 }
 
 function discussionURL(item) {
-  const url = archivePath + '/' + item.month + '/'
-    + (traverse.value == 'date' ? 'maillist.html' : 'threads.html');
+
+  // Given an item from 'meetingData', this returns the URL to either the
+  // by-date (maillist) or by-thread discussion traversal.
+
+  const url = archivePath + '/' + item.dir + '/'
+    + (traverse.value === 'date' ? 'maillist.html' : 'threads.html');
 
   return url;
 }
 
 function parseDiscussionDates(discussionData) {
+
+  // The given dictionary (whose values default to an empty list) is populated
+  // with a mapping of discussion year to a list of months that have archived
+  // discussions.  The value representing each month is an object containing
+  // the month name and subdirectory name.
 
   for (let monthDir of discussionDirs.sort().reverse()) {
 
@@ -271,22 +263,19 @@ const discussionData = defaultDict(() => []);
 
 parseDiscussionDates(discussionData);
 
+// Discussion archives are presented by year, in reverse order from the
+// latest year available (2019). 'discussionYear' is the year the user is
+// currently viewing.  'traverse' is the current selection for traversing
+// the list by-date or by-thread.
+
 const discussionYears = Object.keys(discussionData).sort().reverse();
+
+const discussionYear = ref(discussionYears[0]);
+
+const traverse = ref('date');
+
 </script>
 
 <style lang="scss">
 @import '../../assets/style/globals.scss';
-</style>
-
-<!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped lang="scss">
-
-.fade-enter-active, .fade-leave-active {
-  transition: opacity 0.5s;
-}
-
-.fade-enter, .fade-leave-to {
-  opacity: 0;
-}
-
 </style>

--- a/src/views/ProgramOrganization/Archives.vue
+++ b/src/views/ProgramOrganization/Archives.vue
@@ -68,7 +68,7 @@ import AccordionContent from '@/components/AccordionContent.vue';
 import meetingData from '@/assets/data/boardMeetings.json';
 import {ref} from 'vue';
 
-const archivePath = window.location.host + '/Resources/Media/Archives/Meetings'
+const archivePath = '/Resources/Media/Archives/Meetings'
 
 // This is a list of directory names containing the email discussion archives.
 // The collection of these email discussions ended in 2019, so this list is

--- a/src/views/ProgramOrganization/Board.vue
+++ b/src/views/ProgramOrganization/Board.vue
@@ -31,7 +31,7 @@
                   <ul class="tile-body cve-task-tile-list">
                     <li class="cve-task-tile-list-item">
                       <router-link to="/ProgramOrganization/BoardArchives">
-                        Board Meeting Summaries
+                        Board Meeting Summaries & Email
                       </router-link>
                     </li>
                     <li class="cve-task-tile-list-item">
@@ -42,11 +42,6 @@
                     <li class="cve-task-tile-list-item">
                       <a href="https://marc.info/?l=cve-editorial-board" target="_blank">
                         Board Discussion List &ndash; Mailing list ARChives (MARC)
-                      </a>
-                    </li>
-                    <li class="cve-task-tile-list-item">
-                      <a href="/Resources/Media/Archives/Email/index.html" target="_blank">
-                        Email (2015 - 2021)
                       </a>
                     </li>
                   </ul>

--- a/src/views/ProgramOrganization/Board.vue
+++ b/src/views/ProgramOrganization/Board.vue
@@ -44,6 +44,11 @@
                         Board Discussion List &ndash; Mailing list ARChives (MARC)
                       </a>
                     </li>
+                    <li class="cve-task-tile-list-item">
+                      <a href="/Resources/Media/Archives/Email/index.html" target="_blank">
+                        Email (2015 - 2021)
+                      </a>
+                    </li>
                   </ul>
                 </article>
               </div>

--- a/src/views/ProgramOrganization/Board.vue
+++ b/src/views/ProgramOrganization/Board.vue
@@ -30,9 +30,9 @@
                   </h3>
                   <ul class="tile-body cve-task-tile-list">
                     <li class="cve-task-tile-list-item">
-                      <a href="https://cve.mitre.org/community/board/archive.html#meeting_summaries" target="_blank">
+                      <router-link to="/ProgramOrganization/BoardArchives">
                         Board Meeting Summaries
-                      </a>
+                      </router-link>
                     </li>
                     <li class="cve-task-tile-list-item">
                       <a href="https://www.mail-archive.com/cve-editorial-board-list@mitre.org/" target="_blank">

--- a/src/views/ProgramOrganization/Board.vue
+++ b/src/views/ProgramOrganization/Board.vue
@@ -44,6 +44,11 @@
                         Board Discussion List &ndash; Mailing list ARChives (MARC)
                       </a>
                     </li>
+                    <li class="cve-task-tile-list-item">
+                      <a href="/Resources/Media/Archives/OldWebsite/index.html" target="_blank">
+                        Archived (9/2021) cve.mitre.org website
+                      </a>
+                    </li>
                   </ul>
                 </article>
               </div>


### PR DESCRIPTION
`boardMeetings.json` identifies all the board meetings and links, including the current ones.  I'm working on a script that will search the news and automatically add new meetings as they're announced to this file as they're announced so it will be easy to maintain.

'AccordionContent' is an implementation of the "accordion" construct that's used in the FAQ and other places on the website.  I'm using this for the email archives.  My hope is to replace the code in various places with an instantiation of this component so we've just got one copy of this construct (and this will reduce the code size).

`Archives` is a Vue component responsible for serving the page containing the links to the board meetings and email discussions.  It's launched using the `/ProgramOrganization/BoardArchives` route.

The changes to the `Board` Vue component are what provides access to the new archives navigation and also the snapshot of the old website.
