### PR TITLE
Prevent Bulma Switch to Dark Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
We don't formally support "dark mode" currently. With the Bulma V1 upgrade, Bulma will try to apply a dark mode theme if the user's desktop preference is dark. This change will keep this from happening while we don't dark mode.